### PR TITLE
Add HTTP server with Lua script handling and improve state management

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -98,7 +98,7 @@ jobs:
         with:
           tool: cargo-llvm-cov@0.6.14,cargo-nextest@0.9.87
       - name: Run tests with coverage
-        run: cargo llvm-cov nextest --all-features --workspace --lcov --output-path lcov.info
+        run: cargo llvm-cov nextest --all-features --workspace --ignore-filename-regex main.rs --lcov --output-path lcov.info
       - name: Upload coverage report
         uses: codecov/codecov-action@v5.4.3
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,7 +256,7 @@ dependencies = [
  "home",
  "indexmap 2.10.0",
  "itertools",
- "nu-ansi-term 0.50.1",
+ "nu-ansi-term",
  "once_cell",
  "path_abs",
  "plist",
@@ -1177,8 +1177,8 @@ dependencies = [
  "aho-corasick",
  "bstr",
  "log",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1822,11 +1822,11 @@ dependencies = [
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.1.10",
+ "regex-automata",
 ]
 
 [[package]]
@@ -1995,16 +1995,6 @@ checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
-dependencies = [
- "overload",
- "winapi",
-]
-
-[[package]]
-name = "nu-ansi-term"
 version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
@@ -2084,12 +2074,6 @@ checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
 dependencies = [
  "num-traits",
 ]
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "owo-colors"
@@ -2487,17 +2471,8 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2508,14 +2483,8 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -3163,7 +3132,7 @@ dependencies = [
  "once_cell",
  "onig",
  "plist",
- "regex-syntax 0.8.5",
+ "regex-syntax",
  "serde",
  "serde_derive",
  "serde_json",
@@ -3632,14 +3601,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "matchers",
- "nu-ansi-term 0.46.0",
+ "nu-ansi-term",
  "once_cell",
- "regex",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
@@ -3919,22 +3888,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3942,12 +3895,6 @@ checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
  "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -675,7 +675,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1038,7 +1038,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1727,7 +1727,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2067,9 +2067,9 @@ dependencies = [
 
 [[package]]
 name = "mlua"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab2fea92b2adabd51808311b101551d6e3f8602b65e9fae51f7ad5b3d500f4cd"
+checksum = "5b3dd94c3c4dea0049b22296397040840a8f6b5b5229f438434ba82df402b42d"
 dependencies = [
  "bstr",
  "either",
@@ -2586,7 +2586,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2927,7 +2927,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3441,7 +3441,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4189,7 +4189,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,6 +49,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -142,6 +157,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auto-future"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c1e7e457ea78e524f48639f551fd79703ac3f2237f5ecccdf4708f8a75ad373"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,6 +223,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-test"
+version = "18.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84a5c86736717a01abbe75c16e46972a9d77abde7852f556d4ec5cad859997a0"
+dependencies = [
+ "anyhow",
+ "auto-future",
+ "axum",
+ "bytes",
+ "bytesize 2.0.1",
+ "cookie",
+ "expect-json",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "mime",
+ "pretty_assertions",
+ "reserve-port",
+ "rust-multipart-rfc7578_2",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "smallvec",
+ "tokio",
+ "tower",
+ "url",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -246,7 +297,7 @@ dependencies = [
  "ansi_colours",
  "anyhow",
  "bincode",
- "bytesize",
+ "bytesize 1.3.3",
  "clircle",
  "console",
  "content_inspector",
@@ -347,7 +398,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -370,7 +421,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -453,6 +504,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e93abca9e28e0a1b9877922aacb20576e05d4679ffa78c3d6dc22a26a216659"
 
 [[package]]
+name = "bytesize"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3c8f83209414aacf0eeae3cf730b18d6981697fba62f200fcfb92b9f082acba"
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -489,6 +546,20 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chrono"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "ciborium"
@@ -558,7 +629,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -627,6 +698,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7bda66e858c683005a53a9a60c69a4aca7eeaa45d124526e389f7aec8e62f38"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "time",
+ "version_check",
 ]
 
 [[package]]
@@ -769,7 +850,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -783,7 +864,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -794,7 +875,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -805,7 +886,7 @@ checksum = "e79f8e61677d5df9167cd85265f8e5f64b215cdea3fb55eebc3e622e44c7a146"
 dependencies = [
  "darling_core 0.21.0",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -848,7 +929,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
  "unicode-xid",
 ]
 
@@ -860,6 +941,12 @@ checksum = "ffdd80ce8ce993de27e9f063a444a4d53ce8e8db4c1f00cc03af5ad5a9867a1e"
 dependencies = [
  "cipher",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -880,7 +967,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -897,6 +984,15 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -943,6 +1039,34 @@ checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "expect-json"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7519e78573c950576b89eb4f4fe82aedf3a80639245afa07e3ee3d199dcdb29e"
+dependencies = [
+ "chrono",
+ "email_address",
+ "expect-json-macros",
+ "num",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.16",
+ "typetag",
+ "uuid",
+]
+
+[[package]]
+name = "expect-json-macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bf7f5979e98460a0eb412665514594f68f366a32b85fa8d7ffb65bb1edee6a0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1083,7 +1207,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1327,13 +1451,14 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
- "futures-util",
+ "futures-core",
  "h2",
  "http",
  "http-body",
@@ -1341,6 +1466,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
+ "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1387,6 +1513,30 @@ dependencies = [
  "tower-service",
  "tracing",
  "windows-registry",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1628,7 +1778,7 @@ checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1671,7 +1821,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1722,6 +1872,7 @@ dependencies = [
  "aes",
  "anyhow",
  "axum",
+ "axum-test",
  "base16ct",
  "base64",
  "bat",
@@ -1879,7 +2030,7 @@ checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2003,10 +2154,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2224,13 +2439,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff24dfcda44452b9816fff4cd4227e1bb73ff5a2f1bc1105aa92fb8565ce44d2"
 dependencies = [
  "proc-macro2",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2244,9 +2469,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
@@ -2543,6 +2768,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "reserve-port"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21918d6644020c6f6ef1993242989bf6d4952d2e025617744f184c02df51c356"
+dependencies = [
+ "thiserror 2.0.16",
+]
+
+[[package]]
 name = "rgb"
 version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2628,6 +2862,21 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
+]
+
+[[package]]
+name = "rust-multipart-rfc7578_2"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c839d037155ebc06a571e305af66ff9fd9063a6e662447051737e1ac75beea41"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "mime",
+ "rand 0.9.2",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -2772,7 +3021,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2834,7 +3083,7 @@ checksum = "aafbefbe175fa9bf03ca83ef89beecff7d2a95aaacd5732325b90ac8c3bd7b90"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2897,7 +3146,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3090,9 +3339,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3116,7 +3365,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3235,7 +3484,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3246,7 +3495,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
  "test-case-core",
 ]
 
@@ -3286,7 +3535,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3297,7 +3546,7 @@ checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3402,7 +3651,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3575,7 +3824,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3634,6 +3883,30 @@ name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
+name = "typetag"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f22b40dd7bfe8c14230cf9702081366421890435b2d625fa92b4acc4c3de6f"
+dependencies = [
+ "erased-serde",
+ "inventory",
+ "once_cell",
+ "serde",
+ "typetag-impl",
+]
+
+[[package]]
+name = "typetag-impl"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35f5380909ffc31b4de4f4bdf96b877175a016aa2ca98cee39fcfd8c4d53d952"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
 
 [[package]]
 name = "unicase"
@@ -3797,7 +4070,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
  "wasm-bindgen-shared",
 ]
 
@@ -3832,7 +4105,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3926,7 +4199,7 @@ checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3937,7 +4210,7 @@ checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4178,6 +4451,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
 name = "yoke"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4197,7 +4476,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
  "synstructure",
 ]
 
@@ -4218,7 +4497,7 @@ checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4238,7 +4517,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
  "synstructure",
 ]
 
@@ -4278,5 +4557,5 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2291,6 +2291,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_pipe"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db335f4760b14ead6290116f2427bf33a14d4f0617d49f78a246de10c1831224"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "owo-colors"
 version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3241,9 +3251,13 @@ checksum = "96dcfc4581e3355d70ac2ee14cfdf81dce3d85c85f1ed9e2c1d3013f53b3436b"
 dependencies = [
  "anstream",
  "anstyle",
+ "libc",
  "normalize-line-endings",
+ "os_pipe",
  "similar",
  "snapbox-macros",
+ "wait-timeout",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4013,6 +4027,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,9 +378,9 @@ dependencies = [
 
 [[package]]
 name = "bon"
-version = "3.7.1"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537c317ddf588aab15c695bf92cf55dec159b93221c074180ca3e0e5a94da415"
+checksum = "c2529c31017402be841eb45892278a6c21a000c0a17643af326c73a73f83f0fb"
 dependencies = [
  "bon-macros",
  "rustversion",
@@ -388,9 +388,9 @@ dependencies = [
 
 [[package]]
 name = "bon-macros"
-version = "3.7.1"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca5abbf2d4a4c6896197c9de13d6d7cb7eff438c63dacde1dde980569cb00248"
+checksum = "d82020dadcb845a345591863adb65d74fa8dc5c18a0b6d408470e13b7adc7005"
 dependencies = [
  "darling 0.21.0",
  "ident_case",
@@ -600,9 +600,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.46"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c5e4fcf9c21d2e544ca1ee9d8552de13019a42aa7dbf32747fa7aaf1df76e57"
+checksum = "7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -610,9 +610,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.46"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecb53a0e6fcfb055f686001bc2e2592fa527efaf38dbe81a6a9563562e57d41"
+checksum = "2ad9bbf750e73b5884fb8a211a9424a1906c1e156724260fdae972f31d70e1d6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -622,9 +622,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.45"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14cb31bb0a7d536caef2639baa7fad459e15c3144efefa6dbd1c84562c4739f6"
+checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -675,7 +675,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1038,7 +1038,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1727,7 +1727,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2586,7 +2586,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2927,7 +2927,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3441,7 +3441,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4189,7 +4189,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.16",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,6 +120,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -129,6 +146,60 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "axum"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "backtrace"
@@ -225,6 +296,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -273,7 +356,21 @@ version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad8646f98db542e39fc66e68a20b2144f6a732636df7c2354e74645faaa433ce"
 dependencies = [
+ "borsh-derive",
  "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd1d3c0c2f5833f22386f252fe8ed005c7f59fdcddeef025c01b4c3b9fd9ac3"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -291,6 +388,39 @@ name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "byte-unit"
+version = "5.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cd29c3c585209b0cbc7309bfe3ed7efd8c84c21b7af29c8bfae908f8777174"
+dependencies = [
+ "rust_decimal",
+ "serde",
+ "utf8-width",
+]
+
+[[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "bytecount"
@@ -474,7 +604,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -812,7 +942,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -890,6 +1020,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -1079,6 +1215,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1438,7 +1577,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1582,10 +1721,12 @@ version = "0.1.0"
 dependencies = [
  "aes",
  "anyhow",
+ "axum",
  "base16ct",
  "base64",
  "bat",
  "bon",
+ "byte-unit",
  "bytes",
  "cbc",
  "clap",
@@ -1687,6 +1828,12 @@ checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata 0.1.10",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"
@@ -1816,7 +1963,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "log",
- "rand",
+ "rand 0.9.2",
  "regex",
  "serde_json",
  "serde_urlencoded",
@@ -2103,12 +2250,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2168,7 +2344,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.3",
  "lru-slab",
- "rand",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2191,7 +2367,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2210,13 +2386,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2226,7 +2429,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -2312,6 +2524,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.12.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2376,6 +2597,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rkyv"
+version = "0.7.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9008cd6385b9e161d8229e1f6549dd23c3d022f132a2ea37ac3a10ac4935779b"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "503d1d27590a2b0a3a4ca4c94755aa2875657196ecbf401a42eff41d7de532c0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "rmp"
 version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2412,6 +2662,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_decimal"
+version = "1.37.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b203a6425500a03e0919c42d3c47caca51e79f1132046626d2c8871c5092035d"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "rand 0.8.5",
+ "rkyv",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2433,7 +2699,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2497,6 +2763,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "semver"
@@ -2594,6 +2866,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
+dependencies = [
+ "itoa",
+ "serde",
 ]
 
 [[package]]
@@ -2698,6 +2980,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "similar"
@@ -2906,6 +3194,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "tempfile"
 version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2915,7 +3209,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3259,6 +3553,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3297,6 +3592,7 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3431,6 +3727,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8-width"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86bd8d4e895da8537e5315b8254664e6b769c4ff3db18321b297a1e7004392e3"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3441,6 +3743,16 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f33196643e165781c20a5ead5582283a7dacbb87855d867fbc2df3f81eddc1be"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"
@@ -3628,7 +3940,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3893,6 +4205,15 @@ name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "xterm-color"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 url = "2.5.4"
 
 [dev-dependencies]
+axum-test = "18.0.2"
 criterion = { version = "0.7.0", features = ["async_tokio"] }
 full_moon = "2.0.0"
 mockito = "1.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ criterion = { version = "0.7.0", features = ["async_tokio"] }
 full_moon = "2.0.0"
 mockito = "1.7.0"
 pulldown-cmark = "0.13.0"
-snapbox = "0.6.21"
+snapbox = { version = "0.6.21", features = ["cmd"] }
 test-case = "3.3.1"
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,12 @@ rust-version = "1.85.0"
 [dependencies]
 aes = "0.8.4"
 anyhow = "1.0.98"
+axum = { version = "0.8.4", features = ["http2"] }
 base16ct = { version = "0.3.0", features = ["alloc"] }
 base64 = "0.22.1"
 bat = { version = "0.25.0", default-features = false }
 bon = "3.6.5"
+byte-unit = "5.1.6"
 bytes = "1.10.1"
 cbc = { version = "0.1.2", features = ["alloc"] }
 clap = { version = "4.5.41", features = ["derive", "env"] }
@@ -32,6 +34,7 @@ mlua = { version = "0.11.1", features = [
     "luau",
     "error-send",
     "serde",
+    "send",
     "vendored",
 ] }
 no_color = "0.2.0"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -3,7 +3,7 @@
 use std::io::Cursor;
 
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
-use lmb::Runner;
+use lmb::{Runner, State};
 use rusqlite::Connection;
 use serde_json::json;
 use tokio::io::empty;
@@ -31,9 +31,10 @@ fn lmb_call(c: &mut Criterion) {
         let runner = Runner::builder(source, empty()).build().unwrap();
         c.bench_function("add", |b| {
             b.to_async(&rt).iter(|| async {
+                let state = State::builder().state(json!(1)).build();
                 runner
                     .invoke()
-                    .state(json!(1))
+                    .state(state)
                     .call()
                     .await
                     .unwrap()

--- a/src/bindings/http.rs
+++ b/src/bindings/http.rs
@@ -3,44 +3,33 @@ use std::{str::FromStr, sync::Arc, time::Duration};
 use bon::bon;
 use bytes::BytesMut;
 use mlua::prelude::*;
-use parking_lot::Mutex;
 use reqwest::{
-    Method,
+    Method, StatusCode,
     header::{HeaderMap, HeaderName, HeaderValue},
 };
-use serde_json::{Map, Value};
+use serde_json::{Value, json};
+use tokio::sync::Mutex;
 use tracing::debug_span;
 use url::Url;
 
 use crate::LmbResult;
 
-pub(crate) struct ResponseBinding(Arc<Mutex<reqwest::Response>>);
-
-impl ResponseBinding {
-    pub(crate) fn headers(&self) -> Value {
-        let locked = self.0.lock();
-        let headers = locked.headers();
-        let mut map = Map::new();
-        for (k, v) in headers.iter() {
-            map.insert(
-                k.as_str().to_string(),
-                v.to_str().unwrap_or("").to_string().into(),
-            );
-        }
-        Value::Object(map)
-    }
+pub(crate) struct ResponseBinding {
+    headers: Value,
+    inner: Arc<Mutex<reqwest::Response>>,
+    status: StatusCode,
 }
 
 impl LuaUserData for ResponseBinding {
     fn add_fields<F: LuaUserDataFields<Self>>(fields: &mut F) {
-        fields.add_field_method_get("headers", |vm, this| vm.to_value(&this.headers()));
-        fields.add_field_method_get("ok", |_, this| Ok(this.0.lock().status().is_success()));
-        fields.add_field_method_get("status", |_, this| Ok(this.0.lock().status().as_u16()));
+        fields.add_field_method_get("headers", |vm, this| vm.to_value(&this.headers));
+        fields.add_field_method_get("ok", |_, this| Ok(this.status.is_success()));
+        fields.add_field_method_get("status", |_, this| Ok(this.status.as_u16()));
     }
     fn add_methods<M: LuaUserDataMethods<Self>>(methods: &mut M) {
         methods.add_async_method("json", |vm, this, ()| async move {
             let mut buf = BytesMut::new();
-            while let Some(chunk) = this.0.lock().chunk().await.into_lua_err()? {
+            while let Some(chunk) = this.inner.lock().await.chunk().await.into_lua_err()? {
                 buf.extend_from_slice(&chunk);
             }
             let value: Value = serde_json::from_slice(&buf).into_lua_err()?;
@@ -48,7 +37,7 @@ impl LuaUserData for ResponseBinding {
         });
         methods.add_async_method("text", |_, this, ()| async move {
             let mut buf = BytesMut::new();
-            while let Some(chunk) = this.0.lock().chunk().await.into_lua_err()? {
+            while let Some(chunk) = this.inner.lock().await.chunk().await.into_lua_err()? {
                 buf.extend_from_slice(&chunk);
             }
             String::from_utf8(buf.to_vec()).into_lua_err()
@@ -128,7 +117,25 @@ impl LuaUserData for HttpBinding {
                         debug_span!("send_http_request", method = %method, url = %url).entered();
                     this.client.execute(request).await.into_lua_err()?
                 };
-                Ok(ResponseBinding(Arc::new(Mutex::new(response))))
+                let headers = {
+                    let mut m = json!({});
+                    let headers = response.headers().clone();
+                    for (k, v) in headers {
+                        if let Some(k) = k {
+                            if let Ok(v) = v.to_str() {
+                                m[k.as_str()] = json!(v.to_string());
+                            }
+                        }
+                    }
+                    m
+                };
+                let status_code = response.status();
+                let inner = Arc::new(Mutex::new(response));
+                Ok(ResponseBinding {
+                    headers,
+                    inner,
+                    status: status_code,
+                })
             },
         );
     }
@@ -137,10 +144,10 @@ impl LuaUserData for HttpBinding {
 #[cfg(test)]
 mod tests {
     use reqwest::Method;
-    use serde_json::{Value, json};
+    use serde_json::json;
     use tokio::io::empty;
 
-    use crate::Runner;
+    use crate::{Runner, State};
 
     #[tokio::test]
     async fn test_http_get() {
@@ -156,12 +163,8 @@ mod tests {
 
         let source = include_str!("fixtures/http-get.lua");
         let runner = Runner::builder(source, empty()).build().unwrap();
-        let result = runner
-            .invoke()
-            .state(Value::String(url))
-            .call()
-            .await
-            .unwrap();
+        let state = State::builder().state(json!(url)).build();
+        let result = runner.invoke().state(state).call().await.unwrap();
 
         assert_eq!(json!("Hello, world!"), result.result.unwrap());
 
@@ -185,12 +188,8 @@ mod tests {
 
         let source = include_str!("fixtures/http-post.lua");
         let runner = Runner::builder(source, empty()).build().unwrap();
-        let result = runner
-            .invoke()
-            .state(Value::String(url))
-            .call()
-            .await
-            .unwrap();
+        let state = State::builder().state(json!(url)).build();
+        let result = runner.invoke().state(state).call().await.unwrap();
 
         assert_eq!(json!({"a":1}), result.result.unwrap());
 

--- a/src/bindings/mod.rs
+++ b/src/bindings/mod.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use bon::bon;
 use mlua::prelude::*;
 use tokio::io::{AsyncBufReadExt as _, AsyncRead, AsyncReadExt as _};
-use tracing::debug_span;
+use tracing::{Instrument, debug_span};
 
 use crate::LmbInput;
 
@@ -53,69 +53,70 @@ where
             vm.to_value(&value)
         });
 
-        methods.add_async_method("read_unicode", |vm, this, fmt: LuaValue| async move {
-            let reader = &this.reader;
+        methods.add_async_method("read_unicode", |vm, this, fmt: LuaValue| {
+            let span = debug_span!("read_unicode", fmt = ?fmt);
+            async move {
+                let reader = &this.reader;
 
-            if let Some(f) = fmt.as_string().and_then(|s| s.to_str().ok()) {
-                match &*f {
-                    "*a" | "*all" => {
-                        let _ = debug_span!("read_unicode_all").entered();
-                        let mut buf = String::new();
-                        reader.lock().await.read_to_string(&mut buf).await?;
-                        return vm.to_value(&buf);
-                    }
-                    "*l" | "*line" => {
-                        let _ = debug_span!("read_unicode_line").entered();
-                        let mut line = String::new();
-                        if reader.lock().await.read_line(&mut line).await? == 0 {
-                            return Ok(LuaNil);
+                if let Some(f) = fmt.as_string().and_then(|s| s.to_str().ok()) {
+                    match &*f {
+                        "*a" | "*all" => {
+                            let mut buf = String::new();
+                            reader.lock().await.read_to_string(&mut buf).await?;
+                            return vm.to_value(&buf);
                         }
-                        return vm.to_value(&line.trim_end());
-                    }
-                    _ => {
-                        return Err(LuaError::BadArgument {
-                            to: Some("read".to_string()),
-                            pos: 1,
-                            name: None,
-                            cause: Arc::new(LuaError::external(format!("invalid format {f}"))),
-                        });
+                        "*l" | "*line" => {
+                            let mut line = String::new();
+                            if reader.lock().await.read_line(&mut line).await? == 0 {
+                                return Ok(LuaNil);
+                            }
+                            return vm.to_value(&line.trim_end());
+                        }
+                        _ => {
+                            return Err(LuaError::BadArgument {
+                                to: Some("read".to_string()),
+                                pos: 1,
+                                name: None,
+                                cause: Arc::new(LuaError::external(format!("invalid format {f}"))),
+                            });
+                        }
                     }
                 }
-            }
 
-            if let Some(n) = fmt.as_usize() {
-                let _ = debug_span!("read_unicode_bytes", %n).entered();
-                let mut remaining = n;
-                let mut buf = vec![];
-                let mut single = [0u8; 1];
-                while remaining > 0 {
-                    let count = reader.lock().await.read(&mut single).await?;
-                    if count == 0 {
-                        break;
+                if let Some(n) = fmt.as_usize() {
+                    let mut remaining = n;
+                    let mut buf = vec![];
+                    let mut single = [0u8; 1];
+                    while remaining > 0 {
+                        let count = reader.lock().await.read(&mut single).await?;
+                        if count == 0 {
+                            break;
+                        }
+                        buf.extend_from_slice(&single);
+                        if std::str::from_utf8(&buf).is_ok() {
+                            remaining -= 1;
+                        }
                     }
-                    buf.extend_from_slice(&single);
-                    if std::str::from_utf8(&buf).is_ok() {
-                        remaining -= 1;
+                    if buf.is_empty() {
+                        return Ok(LuaNil);
                     }
+                    return Ok(std::str::from_utf8(&buf).ok().map_or_else(
+                        || LuaNil,
+                        |s| {
+                            vm.create_string(s)
+                                .map_or_else(|_| LuaNil, LuaValue::String)
+                        },
+                    ));
                 }
-                if buf.is_empty() {
-                    return Ok(LuaNil);
-                }
-                return Ok(std::str::from_utf8(&buf).ok().map_or_else(
-                    || LuaNil,
-                    |s| {
-                        vm.create_string(s)
-                            .map_or_else(|_| LuaNil, LuaValue::String)
-                    },
-                ));
-            }
 
-            Err(LuaError::BadArgument {
-                to: Some("read".to_string()),
-                pos: 1,
-                name: None,
-                cause: Arc::new(LuaError::external(format!("invalid option {fmt:?}"))),
-            })
+                Err(LuaError::BadArgument {
+                    to: Some("read".to_string()),
+                    pos: 1,
+                    name: None,
+                    cause: Arc::new(LuaError::external(format!("invalid option {fmt:?}"))),
+                })
+            }
+            .instrument(span)
         });
     }
 }

--- a/src/bindings/store.rs
+++ b/src/bindings/store.rs
@@ -57,10 +57,10 @@ impl StoreBinding {
     #[builder]
     pub(crate) fn new(#[builder(start_fn)] store: Option<LmbStore>) -> LmbResult<Self> {
         if let Some(store) = &store {
-            let _ = debug_span!("run_migrations", count = MIGRATIONS.len()).entered();
+            let span = debug_span!("run_migrations", count = MIGRATIONS.len()).entered();
             let conn = store.lock();
             for migration in MIGRATIONS.iter() {
-                let _ = debug_span!("run_migration", migration).entered();
+                let _ = debug_span!(parent: &span, "run_migration", migration).entered();
                 conn.execute_batch(migration).into_lua_err()?;
             }
         }

--- a/src/fixtures/serve-echo.lua
+++ b/src/fixtures/serve-echo.lua
@@ -1,0 +1,26 @@
+function serve_echo(ctx)
+  local request = ctx.request
+  local json = require("@lmb/json")
+
+  local raw = io.read("*a")
+  local ok, parsed = pcall(function()
+    return json.decode(raw)
+  end)
+
+  local body = raw
+  if ok then
+    body = parsed
+  end
+
+  return {
+    body = {
+      method = request.method,
+      path = request.path,
+      query = request.query,
+      headers = request.headers,
+      body = body,
+    },
+  }
+end
+
+return serve_echo

--- a/src/fixtures/serve.lua
+++ b/src/fixtures/serve.lua
@@ -1,0 +1,9 @@
+function serve(ctx)
+  return {
+    body = "<h1>Hello, World!</h1>",
+    headers = { ["content-type"] = "text/html" },
+    status_code = 201,
+  }
+end
+
+return serve

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ use no_color::is_no_color;
 use rusqlite::Connection;
 use serde_json::{Value, json};
 use tokio::io::{self, AsyncWriteExt as _};
-use tracing::{Instrument, Level, debug, debug_span, error};
+use tracing::{Instrument, Level, debug, debug_span, error, info};
 use tracing_subscriber::{EnvFilter, fmt::format::FmtSpan};
 
 const VERSION: &str = env!("APP_VERSION");
@@ -267,7 +267,7 @@ async fn try_main() -> anyhow::Result<()> {
             );
             let app = build_router(app_state);
             let listener = tokio::net::TcpListener::bind(&bind).await?;
-            debug!("Listening on {}", listener.local_addr()?);
+            info!("Listening on {}", listener.local_addr()?);
             axum::serve(listener, app).await?;
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,23 @@
-use std::{io::Read, path::PathBuf, process::ExitCode, time::Duration};
+use std::{
+    collections::HashMap,
+    io::{Cursor, Read},
+    path::PathBuf,
+    process::ExitCode,
+    str::FromStr,
+    sync::Arc,
+    time::Duration,
+};
 
 use anyhow::bail;
+use axum::{
+    Router,
+    body::to_bytes,
+    extract::{Query, Request, State},
+    http::{HeaderName, HeaderValue, Response, status::StatusCode},
+    response::IntoResponse,
+    routing::any,
+};
+use byte_unit::Byte;
 use clap::{Parser, Subcommand};
 use clio::Input;
 use lmb::{
@@ -9,10 +26,10 @@ use lmb::{
 };
 use no_color::is_no_color;
 use rusqlite::Connection;
-use serde_json::Value;
+use serde_json::{Value, json};
 use tokio::io::{self, AsyncWriteExt as _};
-use tracing::{Instrument, debug_span, info};
-use tracing_subscriber::fmt::format::FmtSpan;
+use tracing::{Instrument, Level, debug, debug_span, error};
+use tracing_subscriber::{EnvFilter, fmt::format::FmtSpan};
 
 const VERSION: &str = env!("APP_VERSION");
 
@@ -20,19 +37,25 @@ const VERSION: &str = env!("APP_VERSION");
 #[clap(author, version=VERSION, about, long_about = None)]
 struct Opts {
     /// Allowed environment variables
-    #[clap(long, value_delimiter = ',')]
+    #[clap(long, value_delimiter = ',', env = "ALLOW_ENV")]
     allow_env: Vec<String>,
+    /// Enable debug mode
+    #[clap(long, short = 'd', env = "DEBUG")]
+    debug: bool,
     /// Optional HTTP timeout in seconds
-    #[clap(long)]
+    #[clap(long, env = "HTTP_TIMEOUT")]
     http_timeout: Option<jiff::Span>,
+    /// Disable colored output
+    #[clap(long, env = "NO_COLOR")]
+    no_color: bool,
     /// Disable store usage
-    #[clap(long, action, group = "store")]
+    #[clap(long, action, group = "store", env = "NO_STORE")]
     no_store: bool,
     /// Optional path to the store file
-    #[clap(long, value_parser, group = "store")]
+    #[clap(long, value_parser, group = "store", env = "STORE_PATH")]
     store_path: Option<PathBuf>,
     /// Timeout. Default is 30 seconds, set to 0 for no timeout
-    #[clap(long)]
+    #[clap(long, env = "TIMEOUT")]
     timeout: Option<jiff::Span>,
     #[clap(subcommand)]
     command: Command,
@@ -43,30 +66,59 @@ enum Command {
     /// Evaluate a file
     Eval {
         /// Path to the file to evaluate
-        #[clap(long, value_parser)]
+        #[clap(long, value_parser, env = "FILE_PATH")]
         file: Input,
         /// Optional state to pass to the Lua script
-        #[clap(long, value_parser)]
-        state: Option<Value>,
+        #[clap(long, env = "STATE")]
+        state: Option<String>,
+    },
+    /// Serve a file
+    Serve {
+        /// Bound address and port
+        #[clap(long, default_value = "127.0.0.1:3000", env = "BIND")]
+        bind: String,
+        /// Path to the file to serve
+        #[clap(long, value_parser, env = "FILE_PATH")]
+        file: Input,
+        /// Optional maximum body size
+        #[clap(long, default_value = "100M", env = "MAX_BODY_SIZE")]
+        max_body_size: String,
+        /// Optional state to pass to the Lua script
+        #[clap(long, env = "STATE")]
+        state: Option<String>,
     },
 }
 
 async fn try_main() -> anyhow::Result<()> {
+    let opts = Opts::parse();
+    debug!("Parsed options: {opts:?}");
+
+    let default_directive = if opts.debug {
+        Level::DEBUG
+    } else {
+        Level::WARN
+    };
+    let env_filter = EnvFilter::builder()
+        .with_default_directive(default_directive.into())
+        .from_env_lossy();
+    let no_color = opts.no_color || is_no_color();
     tracing_subscriber::fmt()
-        .with_ansi(!is_no_color())
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_ansi(!no_color)
+        .with_env_filter(env_filter)
         .with_span_events(FmtSpan::CLOSE)
         .compact()
         .init();
 
-    let opts = Opts::parse();
-    info!("Parsed options: {opts:?}");
-
     match opts.command {
         Command::Eval { mut file, state } => {
             let span = debug_span!("eval").entered();
-            info!("Evaluate Lua script: {file:?}");
-            info!("State: {state:?}");
+            debug!("Evaluate Lua script: {file:?}");
+
+            let state = state.as_ref().map(|s| match serde_json::from_str(s) {
+                Ok(value) => value,
+                Err(_) => json!(s.clone()), // treat invalid value as string
+            });
+            debug!("State: {state:?}");
 
             let reader = io::stdin();
             let source = if file.is_local() {
@@ -84,14 +136,14 @@ async fn try_main() -> anyhow::Result<()> {
                 Some(t) if t.is_zero() => None,
                 Some(t) => Some(Duration::try_from(t)?),
             };
-            info!("Using HTTP timeout: {:?}", http_timeout);
+            debug!("Using HTTP timeout: {:?}", http_timeout);
 
             let timeout = match opts.timeout {
                 None => Some(Duration::from_secs(30)),
                 Some(t) if t.is_zero() => None,
                 Some(t) => Some(Duration::try_from(t)?),
             };
-            info!("Using timeout: {:?}", timeout);
+            debug!("Using timeout: {:?}", timeout);
 
             let conn = match (opts.store_path, opts.no_store) {
                 (None, false) => Some(Connection::open_in_memory()?),
@@ -100,7 +152,7 @@ async fn try_main() -> anyhow::Result<()> {
             };
 
             let runner = if let Some(source) = &source {
-                info!("Evaluating Lua code from stdin or a string input");
+                debug!("Evaluating Lua code from stdin or a string input");
                 Runner::builder(source, reader)
                     .allow_env(opts.allow_env)
                     .default_name("(stdin)")
@@ -109,7 +161,7 @@ async fn try_main() -> anyhow::Result<()> {
                     .maybe_timeout(timeout)
                     .build()?
             } else {
-                info!("Evaluating Lua code from file: {:?}", file.path().path());
+                debug!("Evaluating Lua code from file: {:?}", file.path().path());
                 Runner::builder(file.path().path(), reader)
                     .allow_env(opts.allow_env)
                     .maybe_http_timeout(http_timeout)
@@ -120,18 +172,19 @@ async fn try_main() -> anyhow::Result<()> {
 
             let result = {
                 let span2 = debug_span!(parent: &span, "invoke");
+                let state = lmb::State::builder().maybe_state(state).build();
                 runner
                     .invoke()
-                    .maybe_state(state)
+                    .state(state)
                     .call()
                     .instrument(span2)
                     .await?
             };
-            info!("Lua evaluated");
+            debug!("Lua evaluated");
 
             match result.result {
                 Ok(value) => {
-                    info!("Lua evaluation result: {value}");
+                    debug!("Lua evaluation result: {value}");
                     if let Value::String(s) = &value {
                         println!("{s}");
                     } else {
@@ -156,9 +209,202 @@ async fn try_main() -> anyhow::Result<()> {
                 }
             }
         }
+        Command::Serve {
+            bind,
+            mut file,
+            max_body_size,
+            state,
+        } => {
+            let state = state
+                .as_ref()
+                .map(|s| match serde_json::from_str::<Value>(s) {
+                    Ok(value) => value,
+                    Err(_) => json!(s.clone()), // treat invalid value as string
+                });
+            debug!("State: {state:?}");
+
+            let max_body_size = Byte::parse_str(max_body_size, true)?;
+            let max_body_size = usize::try_from(max_body_size.as_u64())?;
+
+            let http_timeout = match opts.http_timeout {
+                None => Some(Duration::from_secs(30)),
+                Some(t) if t.is_zero() => None,
+                Some(t) => Some(Duration::try_from(t)?),
+            };
+            debug!("Using HTTP timeout: {:?}", http_timeout);
+
+            let timeout = match opts.timeout {
+                None => Some(Duration::from_secs(30)),
+                Some(t) if t.is_zero() => None,
+                Some(t) => Some(Duration::try_from(t)?),
+            };
+            debug!("Using timeout: {:?}", timeout);
+
+            let mut source = String::new();
+            file.read_to_string(&mut source)?;
+
+            let name = if file.is_local() {
+                file.path().to_string_lossy().to_string()
+            } else if file.is_std() {
+                "(stdin)".to_string()
+            } else {
+                bail!("Expected a local file or a stdin input, but got: {file}");
+            };
+
+            let app_state = Arc::new(AppState {
+                allow_env: opts.allow_env.clone(),
+                http_timeout,
+                max_body_size,
+                name,
+                no_store: opts.no_store,
+                state,
+                store_path: opts.store_path.clone(),
+                source,
+                timeout,
+            });
+            let app = Router::new()
+                .route("/{*wildcard}", any(request_handler))
+                .route("/", any(request_handler))
+                .with_state(app_state);
+            let listener = tokio::net::TcpListener::bind(&bind).await?;
+            debug!("Listening on {}", listener.local_addr()?);
+            axum::serve(listener, app).await?;
+        }
     }
 
     Ok(())
+}
+
+#[derive(Clone)]
+struct AppState {
+    allow_env: Vec<String>,
+    http_timeout: Option<Duration>,
+    max_body_size: usize,
+    name: String,
+    no_store: bool,
+    state: Option<Value>,
+    store_path: Option<PathBuf>,
+    source: String,
+    timeout: Option<Duration>,
+}
+
+struct AppError(anyhow::Error);
+
+impl IntoResponse for AppError {
+    fn into_response(self) -> axum::response::Response {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Something went wrong {}", self.0),
+        )
+            .into_response()
+    }
+}
+
+impl<E> From<E> for AppError
+where
+    E: Into<anyhow::Error>,
+{
+    fn from(err: E) -> Self {
+        Self(err.into())
+    }
+}
+
+async fn try_request_handler(
+    app_state: Arc<AppState>,
+    query: HashMap<String, String>,
+    req: Request,
+) -> anyhow::Result<Response<String>> {
+    let method = json!(req.method().as_str());
+    let path = json!(req.uri().path());
+    let headers = {
+        let mut m = json!({});
+        for (k, v) in req.headers() {
+            m[k.as_str()] = json!(v.to_str()?);
+        }
+        m
+    };
+    let query = json!(query);
+
+    let bytes = to_bytes(req.into_body(), app_state.max_body_size).await?;
+    let reader = Cursor::new(bytes);
+
+    let conn = match (app_state.store_path.clone(), app_state.no_store) {
+        (None, false) => Some(Connection::open_in_memory()?),
+        (Some(path), false) => Some(Connection::open(path)?),
+        _ => None,
+    };
+
+    debug!("Evaluating Lua code");
+    let runner = Runner::builder(app_state.source.clone(), reader)
+        .allow_env(app_state.allow_env.clone())
+        .default_name(app_state.name.clone())
+        .maybe_http_timeout(app_state.http_timeout)
+        .maybe_store(conn)
+        .maybe_timeout(app_state.timeout)
+        .build()?;
+
+    let request = json!({ "headers": headers, "method": method, "path": path, "query": query });
+    let state = lmb::State::builder()
+        .maybe_state(app_state.state.clone())
+        .request(request)
+        .build();
+    let res = runner.invoke().state(state).call().await?;
+
+    match res.result {
+        Ok(output) => {
+            debug!("Request succeeded: {output}");
+            match output {
+                Value::String(s) => Ok(Response::new(s)),
+                Value::Object(_) => {
+                    let body = output
+                        .pointer("/body")
+                        .map(|v| match v {
+                            Value::String(s) => s.clone(),
+                            _ => v.to_string(),
+                        })
+                        .unwrap_or_default();
+                    let mut res = Response::new(body);
+
+                    let status_code = output.pointer("/status_code").and_then(|v| v.as_u64());
+                    if let Some(status_code) = status_code {
+                        if let Ok(status_code) = u16::try_from(status_code) {
+                            *res.status_mut() = StatusCode::from_u16(status_code)?;
+                        }
+                    }
+
+                    let headers = output.pointer("/headers").and_then(|v| v.as_object());
+                    if let Some(m) = headers {
+                        for (k, v) in m {
+                            if let Some(s) = v.as_str() {
+                                let k = HeaderName::from_str(k.as_str())?;
+                                let v = HeaderValue::from_str(s)?;
+                                res.headers_mut().insert(k, v);
+                            }
+                        }
+                    }
+
+                    Ok(res)
+                }
+                v => Ok(Response::new(v.to_string())),
+            }
+        }
+        Err(err) => {
+            error!("Request failed: {err:?}");
+            Err(err.into())
+        }
+    }
+}
+
+async fn request_handler(
+    State(app_state): State<Arc<AppState>>,
+    Query(query): Query<HashMap<String, String>>,
+    request: Request,
+) -> Result<Response<String>, AppError> {
+    let span = debug_span!("handle_request");
+    let res = try_request_handler(app_state, query, request)
+        .instrument(span)
+        .await?;
+    Ok(res)
 }
 
 #[tokio::main]

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -104,11 +104,13 @@ async fn try_request_handler(
                     let headers = output.pointer("/headers").and_then(|v| v.as_object());
                     if let Some(m) = headers {
                         for (k, v) in m {
-                            if let Some(s) = v.as_str() {
-                                let k = HeaderName::from_str(k.as_str())?;
-                                let v = HeaderValue::from_str(s)?;
-                                res.headers_mut().insert(k, v);
-                            }
+                            let v = match v {
+                                Value::String(s) => s,
+                                _ => &v.to_string(),
+                            };
+                            let k = HeaderName::from_str(k.as_str())?;
+                            let v = HeaderValue::from_str(v)?;
+                            res.headers_mut().insert(k, v);
                         }
                     }
 

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -1,0 +1,185 @@
+use std::{collections::HashMap, io::Cursor, str::FromStr as _, sync::Arc};
+
+use axum::{
+    body::to_bytes,
+    extract::{Query, Request, State},
+    http::{HeaderName, HeaderValue, StatusCode},
+    response::{IntoResponse, Response},
+};
+use lmb::Runner;
+use rusqlite::Connection;
+use serde_json::{Value, json};
+use tracing::{Instrument as _, debug, debug_span, error};
+
+use crate::AppState;
+
+pub(crate) struct AppError(anyhow::Error);
+
+impl IntoResponse for AppError {
+    fn into_response(self) -> axum::response::Response {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Something went wrong {}", self.0),
+        )
+            .into_response()
+    }
+}
+
+impl<E> From<E> for AppError
+where
+    E: Into<anyhow::Error>,
+{
+    fn from(err: E) -> Self {
+        Self(err.into())
+    }
+}
+
+async fn try_request_handler(
+    app_state: Arc<AppState>,
+    query: HashMap<String, String>,
+    req: Request,
+) -> anyhow::Result<Response<String>> {
+    let method = json!(req.method().as_str());
+    let path = json!(req.uri().path());
+    let headers = {
+        let mut m = json!({});
+        for (k, v) in req.headers() {
+            m[k.as_str()] = json!(v.to_str()?);
+        }
+        m
+    };
+    let query = json!(query);
+
+    let bytes = to_bytes(
+        req.into_body(),
+        app_state.max_body_size.unwrap_or(10 * 1_024 * 1_024),
+    )
+    .await?;
+    let reader = Cursor::new(bytes);
+
+    let conn = match (app_state.store_path.clone(), app_state.no_store) {
+        (None, None) => Some(Connection::open_in_memory()?),
+        (Some(path), None) => Some(Connection::open(path)?),
+        _ => None,
+    };
+
+    debug!("Evaluating Lua code");
+    let runner = Runner::builder(app_state.source.clone(), reader)
+        .maybe_allow_env(app_state.allow_env.clone())
+        .maybe_default_name(app_state.name.clone())
+        .maybe_http_timeout(app_state.http_timeout)
+        .maybe_store(conn)
+        .maybe_timeout(app_state.timeout)
+        .build()?;
+
+    let request = json!({ "headers": headers, "method": method, "path": path, "query": query });
+    let state = lmb::State::builder()
+        .maybe_state(app_state.state.clone())
+        .request(request)
+        .build();
+    let res = runner.invoke().state(state).call().await?;
+
+    match res.result {
+        Ok(output) => {
+            debug!("Request succeeded: {output}");
+            match output {
+                Value::String(s) => Ok(Response::new(s)),
+                Value::Object(_) => {
+                    let body = output
+                        .pointer("/body")
+                        .map(|v| match v {
+                            Value::String(s) => s.clone(),
+                            _ => v.to_string(),
+                        })
+                        .unwrap_or_default();
+                    let mut res = Response::new(body);
+
+                    let status_code = output.pointer("/status_code").and_then(|v| v.as_u64());
+                    if let Some(status_code) = status_code {
+                        if let Ok(status_code) = u16::try_from(status_code) {
+                            *res.status_mut() = StatusCode::from_u16(status_code)?;
+                        }
+                    }
+
+                    let headers = output.pointer("/headers").and_then(|v| v.as_object());
+                    if let Some(m) = headers {
+                        for (k, v) in m {
+                            if let Some(s) = v.as_str() {
+                                let k = HeaderName::from_str(k.as_str())?;
+                                let v = HeaderValue::from_str(s)?;
+                                res.headers_mut().insert(k, v);
+                            }
+                        }
+                    }
+
+                    Ok(res)
+                }
+                v => Ok(Response::new(v.to_string())),
+            }
+        }
+        Err(err) => {
+            error!("Request failed: {err:?}");
+            Err(err.into())
+        }
+    }
+}
+
+pub(crate) async fn request_handler(
+    State(app_state): State<Arc<AppState>>,
+    Query(query): Query<HashMap<String, String>>,
+    request: Request,
+) -> Result<Response<String>, AppError> {
+    let span = debug_span!("handle_request");
+    let res = try_request_handler(app_state, query, request)
+        .instrument(span)
+        .await?;
+    Ok(res)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use axum_test::TestServer;
+    use serde_json::{Value, json};
+
+    use crate::{AppState, build_router};
+
+    #[tokio::test]
+    async fn test_serve() {
+        let source = include_str!("./fixtures/serve.lua");
+        let app_state = Arc::new(AppState::builder().source(source).build());
+        let router = build_router(app_state);
+        let server = TestServer::new(router).unwrap();
+
+        let res = server.get("/").await;
+        assert_eq!(201, res.status_code());
+        assert_eq!("text/html", res.headers().get("content-type").unwrap());
+        assert_eq!("<h1>Hello, World!</h1>", res.text());
+    }
+
+    #[tokio::test]
+    async fn test_serve_echo() {
+        let source = include_str!("./fixtures/serve-echo.lua");
+        let app_state = Arc::new(AppState::builder().source(source).build());
+        let router = build_router(app_state);
+        let server = TestServer::new(router).unwrap();
+
+        let res = server
+            .post("/a/b/c?a=1&b=2")
+            .add_header("i-am", "teapot")
+            .json(&json!({ "foo": 1, "bar": 2 }))
+            .await;
+        assert_eq!(200, res.status_code());
+        assert_eq!(
+            json!({
+                "body": { "foo": 1, "bar": 2 },
+                "headers": { "content-type": "application/json", "i-am": "teapot" },
+                "method": "POST",
+                "path": "/a/b/c",
+                "query": { "a": "1", "b": "2" }
+            }),
+            res.json::<Value>()
+        );
+    }
+}

--- a/tests/guided_tour.rs
+++ b/tests/guided_tour.rs
@@ -1,10 +1,10 @@
 use std::{io::Cursor, time::Duration};
 
 use full_moon::{tokenizer::TokenType, visitors::Visitor};
-use lmb::Runner;
+use lmb::{Runner, State};
 use pulldown_cmark::{CodeBlockKind, Event, Options, Parser, Tag, TagEnd};
 use rusqlite::Connection;
-use serde_json::Value;
+use serde_json::{Value, json};
 use toml::Table;
 
 #[derive(Default)]
@@ -109,7 +109,7 @@ async fn test_guided_tour() {
             .await;
         if let Some(ref mut state) = visitor.state {
             if let Some(state) = state.as_object_mut() {
-                state.insert("url".to_string(), Value::String(server.url()));
+                state.insert("url".to_string(), json!(server.url()));
             }
         }
 
@@ -124,9 +124,10 @@ async fn test_guided_tour() {
             .maybe_timeout(visitor.timeout)
             .build()
             .unwrap();
+        let state = State::builder().maybe_state(visitor.state).build();
         let value = runner
             .invoke()
-            .maybe_state(visitor.state)
+            .state(state)
             .call()
             .await
             .unwrap()

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,3 +1,8 @@
+use std::{
+    net::{Ipv4Addr, SocketAddrV4},
+    time::Duration,
+};
+
 use reqwest::Method;
 use snapbox::{
     cmd::{Command, cargo_bin},
@@ -179,6 +184,27 @@ fn eval_stdin_error() {
  5 |   return a
    `----
 Error: Lua value as error: "(stdin):3: An error occurred"
+
+"#]]);
+}
+
+#[test]
+fn serve() {
+    let bind = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0);
+    Command::new(cargo_bin("lmb"))
+        .timeout(Duration::from_millis(100))
+        .env("RUST_LOG", "lmb=info")
+        .env("NO_COLOR", "true")
+        .args([
+            "serve",
+            "--file",
+            "src/fixtures/serve.lua",
+            "--bind",
+            &format!("{bind}"),
+        ])
+        .assert()
+        .stdout_eq(str![[r#"
+[..]  INFO lmb: Listening on 0.0.0.0:[..]
 
 "#]]);
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -21,7 +21,7 @@ fn eval_add() {
 fn eval_env() {
     Command::new(cargo_bin("lmb"))
         .env("FOO", "bar")
-        .env("NO_COLOR", "1")
+        .env("NO_COLOR", "true")
         .args([
             "--allow-env",
             "FOO",
@@ -41,7 +41,7 @@ bar
 #[test]
 fn eval_error() {
     Command::new(cargo_bin("lmb"))
-        .env("NO_COLOR", "1")
+        .env("NO_COLOR", "true")
         .args(["eval", "--file", "src/fixtures/error.lua"])
         .assert()
         .failure()
@@ -112,20 +112,20 @@ null
 #[test]
 fn eval_infinite() {
     Command::new(cargo_bin("lmb"))
-        .env("NO_COLOR", "1")
+        .env("NO_COLOR", "true")
         .args([
+            "--timeout",
+            "100ms",
             "eval",
             "--file",
             "src/fixtures/infinite.lua",
-            "--timeout",
-            "100ms",
         ])
         .assert()
         .failure()
         .stdout_eq(str![])
         .stderr_eq(str![[r#"
-Timeout: Lua script execution timed out after 100[..]ms, timeout was 100ms
-Error: Timeout: Lua script execution timed out after 100[..]ms, timeout was 100ms
+Timeout: Lua script execution timed out after [..]ms, timeout was 100ms
+Error: Timeout: Lua script execution timed out after [..]ms, timeout was 100ms
 
 "#]]);
 }
@@ -133,7 +133,7 @@ Error: Timeout: Lua script execution timed out after 100[..]ms, timeout was 100m
 #[test]
 fn eval_no_export() {
     Command::new(cargo_bin("lmb"))
-        .env("NO_COLOR", "1")
+        .env("NO_COLOR", "true")
         .args(["eval", "--file", "src/fixtures/no-export.lua"])
         .assert()
         .success()
@@ -147,7 +147,7 @@ null
 #[test]
 fn eval_stdin_expression() {
     Command::new(cargo_bin("lmb"))
-        .env("NO_COLOR", "1")
+        .env("NO_COLOR", "true")
         .stdin("return 'Hello, world!'")
         .args(["eval", "--file", "-"])
         .assert()
@@ -162,7 +162,7 @@ Hello, world!
 #[test]
 fn eval_stdin_error() {
     Command::new(cargo_bin("lmb"))
-        .env("NO_COLOR", "1")
+        .env("NO_COLOR", "true")
         .stdin(include_str!("../src/fixtures/error.lua"))
         .args(["eval", "--file", "-"])
         .assert()

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,8 +1,3 @@
-use std::{
-    net::{Ipv4Addr, SocketAddrV4},
-    time::Duration,
-};
-
 use reqwest::Method;
 use snapbox::{
     cmd::{Command, cargo_bin},
@@ -184,27 +179,6 @@ fn eval_stdin_error() {
  5 |   return a
    `----
 Error: Lua value as error: "(stdin):3: An error occurred"
-
-"#]]);
-}
-
-#[test]
-fn serve() {
-    let bind = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0);
-    Command::new(cargo_bin("lmb"))
-        .timeout(Duration::from_millis(100))
-        .env("RUST_LOG", "lmb=info")
-        .env("NO_COLOR", "true")
-        .args([
-            "serve",
-            "--file",
-            "src/fixtures/serve.lua",
-            "--bind",
-            &format!("{bind}"),
-        ])
-        .assert()
-        .stdout_eq(str![[r#"
-[..]  INFO lmb: Listening on 0.0.0.0:[..]
 
 "#]]);
 }


### PR DESCRIPTION
Introduce an HTTP server using `axum` to serve Lua scripts, enhance state management for Lua execution, and improve error handling and logging. Adjust command options for clarity and update timeout handling.