### PR TITLE
fix: use musl.cc toolchain for arm64 cross-compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,17 @@
 # Stage 1: Chef - prepare recipe (runs on build platform)
 FROM --platform=$BUILDPLATFORM rust:1.92-alpine AS chef
-RUN apk add --no-cache musl-dev g++
+
+ARG TARGETPLATFORM
+
+# Install base build dependencies
+RUN apk add --no-cache musl-dev g++ curl
+
+# Download musl.cc cross-compiler for arm64 cross-compilation
+RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
+        curl -fsSL https://musl.cc/aarch64-linux-musl-cross.tgz | tar -xz -C /opt && \
+        ln -s /opt/aarch64-linux-musl-cross/bin/* /usr/local/bin/; \
+    fi
+
 RUN cargo install cargo-chef
 WORKDIR /app
 
@@ -15,15 +26,10 @@ FROM chef AS builder
 ARG TARGETPLATFORM
 ARG GIT_VERSION=dev
 
-# Install cross-compilation toolchain based on target
+# Add Rust target based on platform
 RUN case "$TARGETPLATFORM" in \
-        "linux/arm64") \
-            apk add --no-cache aarch64-none-elf-gcc && \
-            rustup target add aarch64-unknown-linux-musl \
-            ;; \
-        "linux/amd64") \
-            rustup target add x86_64-unknown-linux-musl \
-            ;; \
+        "linux/arm64") rustup target add aarch64-unknown-linux-musl ;; \
+        "linux/amd64") rustup target add x86_64-unknown-linux-musl ;; \
     esac
 
 WORKDIR /app
@@ -33,9 +39,14 @@ RUN mkdir -p .cargo && \
     case "$TARGETPLATFORM" in \
         "linux/arm64") \
             echo '[target.aarch64-unknown-linux-musl]' >> .cargo/config.toml && \
-            echo 'linker = "aarch64-none-elf-gcc"' >> .cargo/config.toml \
+            echo 'linker = "aarch64-linux-musl-gcc"' >> .cargo/config.toml \
             ;; \
     esac
+
+# Set environment variables for cc crate cross-compilation
+ENV CC_aarch64_unknown_linux_musl=aarch64-linux-musl-gcc
+ENV CXX_aarch64_unknown_linux_musl=aarch64-linux-musl-g++
+ENV AR_aarch64_unknown_linux_musl=aarch64-linux-musl-ar
 
 # Set the Rust target based on platform
 RUN case "$TARGETPLATFORM" in \


### PR DESCRIPTION
## Summary

- Download `aarch64-linux-musl-cross` toolchain from musl.cc in chef stage
- Remove non-existent `aarch64-none-elf-gcc` package from Alpine
- Update linker to use correct `aarch64-linux-musl-gcc` binary
- Add `CC`, `CXX`, `AR` environment variables for cc crate cross-compilation

## Problem

The Docker build was failing on ARM64 because Alpine Linux doesn't have the `aarch64-none-elf-gcc` package. This package is for bare-metal/embedded targets, not Linux musl targets.

```
ERROR: unable to select packages:
  aarch64-none-elf-gcc (no such package)
```

## Solution

Use the musl.cc pre-built `aarch64-linux-musl-cross` toolchain which provides a complete GCC/G++ cross-compilation environment specifically designed for musl libc targets.

## Test plan

- [ ] CI Docker build succeeds for linux/arm64 platform
- [ ] CI Docker build succeeds for linux/amd64 platform
- [ ] Built ARM64 image runs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)