### PR TITLE
feat: switch Dockerfile from musl to glibc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ARG GIT_VERSION=dev
 # Install cross-compilation toolchain based on target
 RUN case "$TARGETPLATFORM" in \
         "linux/arm64") \
-            apt-get update && apt-get install -y gcc-aarch64-linux-gnu && \
+            apt-get update && apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu && \
             rustup target add aarch64-unknown-linux-gnu \
             ;; \
         "linux/amd64") \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 # Stage 1: Chef - prepare recipe (runs on build platform)
-FROM --platform=$BUILDPLATFORM rust:1.92-alpine AS chef
-RUN apk add --no-cache musl-dev g++
+FROM --platform=$BUILDPLATFORM rust:1.92-bookworm AS chef
 RUN cargo install cargo-chef
 WORKDIR /app
 
@@ -12,36 +11,35 @@ RUN cargo chef prepare --recipe-path recipe.json
 # Stage 3: Builder - cross-compile for target platform
 FROM chef AS builder
 
+# Target platform args (set by docker buildx)
 ARG TARGETPLATFORM
 ARG GIT_VERSION=dev
 
 # Install cross-compilation toolchain based on target
 RUN case "$TARGETPLATFORM" in \
         "linux/arm64") \
-            apk add --no-cache aarch64-none-elf-gcc && \
-            rustup target add aarch64-unknown-linux-musl \
+            apt-get update && apt-get install -y gcc-aarch64-linux-gnu && \
+            rustup target add aarch64-unknown-linux-gnu \
             ;; \
         "linux/amd64") \
-            rustup target add x86_64-unknown-linux-musl \
+            # Native build, no extra toolchain needed \
             ;; \
     esac
-
-WORKDIR /app
 
 # Configure cargo for cross-compilation
 RUN mkdir -p .cargo && \
     case "$TARGETPLATFORM" in \
         "linux/arm64") \
-            echo '[target.aarch64-unknown-linux-musl]' >> .cargo/config.toml && \
-            echo 'linker = "aarch64-none-elf-gcc"' >> .cargo/config.toml \
+            echo '[target.aarch64-unknown-linux-gnu]' >> .cargo/config.toml && \
+            echo 'linker = "aarch64-linux-gnu-gcc"' >> .cargo/config.toml \
             ;; \
     esac
 
 # Set the Rust target based on platform
 RUN case "$TARGETPLATFORM" in \
-        "linux/arm64") echo "aarch64-unknown-linux-musl" > /tmp/rust_target ;; \
-        "linux/amd64") echo "x86_64-unknown-linux-musl" > /tmp/rust_target ;; \
-        *) echo "x86_64-unknown-linux-musl" > /tmp/rust_target ;; \
+        "linux/arm64") echo "aarch64-unknown-linux-gnu" > /tmp/rust_target ;; \
+        "linux/amd64") echo "x86_64-unknown-linux-gnu" > /tmp/rust_target ;; \
+        *) echo "x86_64-unknown-linux-gnu" > /tmp/rust_target ;; \
     esac
 
 COPY --from=planner /app/recipe.json recipe.json
@@ -58,7 +56,7 @@ RUN RUST_TARGET=$(cat /tmp/rust_target) && \
     cp target/$RUST_TARGET/release/lmb /app/lmb
 
 # Stage 4: Runtime - distroless for minimal image
-FROM gcr.io/distroless/static-debian12
+FROM gcr.io/distroless/cc-debian12
 
 COPY --from=builder /app/lmb /lmb
 


### PR DESCRIPTION
## Summary
- Switch Docker build from Alpine + musl to Debian bookworm + glibc
- Use `gcr.io/distroless/cc-debian12` as runtime image (includes glibc)
- Add C++ cross-compiler (`g++-aarch64-linux-gnu`) for arm64 builds to fix mlua-sys compilation

## Why
musl has known compatibility issues with some libraries. Using glibc provides better compatibility.

## Changes
| Item | Old (musl) | New (glibc) |
|------|------------|-------------|
| Build image | `rust:1.92-alpine` | `rust:1.92-bookworm` |
| ARM64 cross-compiler | `aarch64-none-elf-gcc` | `gcc-aarch64-linux-gnu` + `g++-aarch64-linux-gnu` |
| Rust target (AMD64) | `x86_64-unknown-linux-musl` | `x86_64-unknown-linux-gnu` |
| Rust target (ARM64) | `aarch64-unknown-linux-musl` | `aarch64-unknown-linux-gnu` |
| Runtime image | `gcr.io/distroless/static-debian12` | `gcr.io/distroless/cc-debian12` |

## Test plan
- [x] Local build: `docker build -t lmb:test .`
- [x] Multi-platform build: `docker buildx build --platform linux/amd64,linux/arm64 -t lmb:test .`
- [x] Verify binary runs: `docker run --rm lmb:test --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)