### PR TITLE
feat: add module documentation, improve tests and benchmarks

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -111,6 +111,30 @@ fn lmb_call(c: &mut Criterion) {
                 .iter(|| async { runner.invoke().call().await.unwrap().result.unwrap() });
         });
     }
+    {
+        let source = include_str!("fixtures/yaml.lua");
+        let runner = Runner::builder(source, empty()).build().unwrap();
+        c.bench_function("yaml encode decode", |b| {
+            b.to_async(&rt)
+                .iter(|| async { runner.invoke().call().await.unwrap().result.unwrap() });
+        });
+    }
+    {
+        let source = include_str!("fixtures/toml.lua");
+        let runner = Runner::builder(source, empty()).build().unwrap();
+        c.bench_function("toml encode decode", |b| {
+            b.to_async(&rt)
+                .iter(|| async { runner.invoke().call().await.unwrap().result.unwrap() });
+        });
+    }
+    {
+        let source = include_str!("fixtures/pool.lua");
+        let runner = Runner::builder(source, empty()).build().unwrap();
+        c.bench_function("pool concurrent", |b| {
+            b.to_async(&rt)
+                .iter(|| async { runner.invoke().call().await.unwrap().result.unwrap() });
+        });
+    }
 }
 
 criterion_group!(lmb, lmb_call);

--- a/benches/fixtures/pool.lua
+++ b/benches/fixtures/pool.lua
@@ -1,0 +1,32 @@
+local co = require("@lmb/coroutine")
+
+-- Simulate work with a small computation
+local function work()
+    local sum = 0
+    for i = 1, 100 do
+        sum = sum + i
+    end
+    return sum
+end
+
+-- Create multiple coroutines to simulate concurrent requests
+local threads = {}
+for i = 1, 10 do
+    threads[i] = coroutine.create(function()
+        return work()
+    end)
+end
+
+-- Run all concurrently
+local results = co.join_all(threads)
+
+-- Verify all completed successfully
+local all_ok = true
+for _, result in ipairs(results) do
+    if result ~= 5050 then
+        all_ok = false
+        break
+    end
+end
+
+return all_ok

--- a/benches/fixtures/toml.lua
+++ b/benches/fixtures/toml.lua
@@ -1,0 +1,16 @@
+local toml = require("@lmb/toml")
+
+local data = {
+    name = "benchmark",
+    version = 1,
+    enabled = true,
+    config = {
+        timeout = 30,
+        retries = 3
+    }
+}
+
+local encoded = toml.encode(data)
+local decoded = toml.decode(encoded)
+
+return decoded.name == "benchmark"

--- a/benches/fixtures/yaml.lua
+++ b/benches/fixtures/yaml.lua
@@ -1,0 +1,17 @@
+local yaml = require("@lmb/yaml")
+
+local data = {
+    name = "benchmark",
+    version = 1,
+    enabled = true,
+    tags = {"lua", "yaml", "benchmark"},
+    config = {
+        timeout = 30,
+        retries = 3
+    }
+}
+
+local encoded = yaml.encode(data)
+local decoded = yaml.decode(encoded)
+
+return decoded.name == "benchmark"

--- a/src/bindings/coroutine.rs
+++ b/src/bindings/coroutine.rs
@@ -1,3 +1,42 @@
+//! Coroutine utilities binding module.
+//!
+//! This module provides JavaScript Promise-like utilities for working with Lua coroutines.
+//! Import via `require("@lmb/coroutine")`.
+//!
+//! # Available Methods
+//!
+//! - `all_settled(coroutines)` - Wait for all coroutines to complete, returning results with status.
+//! - `join_all(coroutines)` - Wait for all coroutines to complete successfully, fails if any fails.
+//! - `race(coroutines)` - Return the result of the first coroutine to complete.
+//!
+//! # Example
+//!
+//! ```lua
+//! local co = require("@lmb/coroutine")
+//!
+//! -- Create coroutines
+//! local threads = {
+//!     coroutine.create(function() sleep_ms(10); return 1 end),
+//!     coroutine.create(function() sleep_ms(20); return 2 end),
+//! }
+//!
+//! -- Wait for all to complete
+//! local results = co.join_all(threads)
+//!
+//! -- Race to get first result
+//! local first = co.race(threads)
+//!
+//! -- Get all results with status
+//! local settled = co.all_settled(threads)
+//! for _, r in ipairs(settled) do
+//!     if r.status == "fulfilled" then
+//!         print(r.value)
+//!     else
+//!         print(r.reason)
+//!     end
+//! end
+//! ```
+
 use futures::{StreamExt as _, stream::FuturesUnordered};
 use mlua::prelude::*;
 

--- a/src/bindings/crypto.rs
+++ b/src/bindings/crypto.rs
@@ -1,3 +1,63 @@
+//! Cryptographic functions binding module.
+//!
+//! This module provides cryptographic utilities for hashing, encoding, and encryption.
+//! Import via `require("@lmb/crypto")`.
+//!
+//! # Available Methods
+//!
+//! ## Encoding
+//! - `base64_encode(data)` - Encode data to base64 string.
+//! - `base64_decode(data)` - Decode base64 string to data.
+//!
+//! ## Hashing
+//! - `crc32(data)` - Compute CRC32 checksum (hex string).
+//! - `md5(data)` - Compute MD5 hash (hex string).
+//! - `sha1(data)` - Compute SHA-1 hash (hex string).
+//! - `sha256(data)` - Compute SHA-256 hash (hex string).
+//! - `sha384(data)` - Compute SHA-384 hash (hex string).
+//! - `sha512(data)` - Compute SHA-512 hash (hex string).
+//! - `hmac(algorithm, data, secret)` - Compute HMAC (sha1, sha256, sha384, sha512).
+//!
+//! ## Encryption/Decryption
+//! - `encrypt(cipher, data, key, iv)` - Encrypt data using specified cipher.
+//! - `decrypt(cipher, encrypted, key, iv)` - Decrypt data using specified cipher.
+//!
+//! # Supported Ciphers
+//!
+//! | Cipher     | Key Size | IV Size | Notes                    |
+//! |------------|----------|---------|--------------------------|
+//! | `aes-cbc`  | 16 bytes | 16 bytes| AES-128 in CBC mode      |
+//! | `des-cbc`  | 8 bytes  | 8 bytes | DES in CBC mode          |
+//! | `des-ecb`  | 8 bytes  | N/A     | DES in ECB mode (no IV)  |
+//!
+//! # Security Warning
+//!
+//! - **DES is considered insecure** for modern applications. Use AES when possible.
+//! - **MD5 and SHA-1** should not be used for security-critical hashing.
+//! - Always use cryptographically secure random values for keys and IVs.
+//!
+//! # Example
+//!
+//! ```lua
+//! local crypto = require("@lmb/crypto")
+//!
+//! -- Base64 encoding
+//! local encoded = crypto.base64_encode("Hello")
+//! local decoded = crypto.base64_decode(encoded)
+//!
+//! -- Hashing
+//! local hash = crypto.sha256("password")
+//!
+//! -- HMAC
+//! local hmac = crypto.hmac("sha256", "message", "secret")
+//!
+//! -- AES encryption (key and IV must be 16 bytes)
+//! local key = "1234567890123456"
+//! local iv = "abcdefghijklmnop"
+//! local encrypted = crypto.encrypt("aes-cbc", "plaintext", key, iv)
+//! local decrypted = crypto.decrypt("aes-cbc", encrypted, key, iv)
+//! ```
+
 use std::{fmt, sync::Arc};
 
 use aes::cipher::{BlockDecryptMut as _, BlockEncryptMut as _, block_padding::Pkcs7};
@@ -142,6 +202,41 @@ mod tests {
     #[tokio::test]
     async fn test_crypto() {
         let source = include_str!("../fixtures/bindings/crypto.lua");
+        let runner = Runner::builder(source, empty()).build().unwrap();
+        runner.invoke().call().await.unwrap().result.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_crypto_errors() {
+        let source = include_str!("../fixtures/bindings/crypto-errors.lua");
+        let runner = Runner::builder(source, empty()).build().unwrap();
+        runner.invoke().call().await.unwrap().result.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_base64_roundtrip() {
+        let source = include_str!("../fixtures/bindings/crypto/base64-roundtrip.lua");
+        let runner = Runner::builder(source, empty()).build().unwrap();
+        runner.invoke().call().await.unwrap().result.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_hash_functions() {
+        let source = include_str!("../fixtures/bindings/crypto/hash-functions.lua");
+        let runner = Runner::builder(source, empty()).build().unwrap();
+        runner.invoke().call().await.unwrap().result.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_des_ecb_encryption() {
+        let source = include_str!("../fixtures/bindings/crypto/des-ecb.lua");
+        let runner = Runner::builder(source, empty()).build().unwrap();
+        runner.invoke().call().await.unwrap().result.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_des_cbc_encryption() {
+        let source = include_str!("../fixtures/bindings/crypto/des-cbc.lua");
         let runner = Runner::builder(source, empty()).build().unwrap();
         runner.invoke().call().await.unwrap().result.unwrap();
     }

--- a/src/bindings/globals.rs
+++ b/src/bindings/globals.rs
@@ -1,3 +1,18 @@
+//! Global functions binding module.
+//!
+//! This module provides global Lua functions that are available without requiring any module import.
+//!
+//! # Available Functions
+//!
+//! - `sleep_ms(ms)` - Asynchronously sleep for the specified number of milliseconds.
+//!
+//! # Example
+//!
+//! ```lua
+//! -- Sleep for 100 milliseconds
+//! sleep_ms(100)
+//! ```
+
 use crate::{LmbResult, Runner};
 
 pub(crate) fn bind(runner: &mut Runner) -> LmbResult<()> {
@@ -12,4 +27,33 @@ pub(crate) fn bind(runner: &mut Runner) -> LmbResult<()> {
     )?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Instant;
+
+    use tokio::io::empty;
+
+    use crate::Runner;
+
+    #[tokio::test]
+    async fn test_sleep_ms() {
+        let source = include_str!("../fixtures/bindings/globals/sleep.lua");
+        let runner = Runner::builder(source, empty()).build().unwrap();
+        let start = Instant::now();
+        let result = runner.invoke().call().await.unwrap();
+        let elapsed = start.elapsed();
+        assert!(result.result.is_ok());
+        // Verify that sleep actually waited (at least 40ms to allow for timing variance)
+        assert!(elapsed.as_millis() >= 40);
+    }
+
+    #[tokio::test]
+    async fn test_sleep_ms_zero() {
+        let source = include_str!("../fixtures/bindings/globals/sleep-zero.lua");
+        let runner = Runner::builder(source, empty()).build().unwrap();
+        let result = runner.invoke().call().await.unwrap();
+        assert!(result.result.is_ok());
+    }
 }

--- a/src/bindings/http.rs
+++ b/src/bindings/http.rs
@@ -1,3 +1,56 @@
+//! HTTP client binding module.
+//!
+//! This module provides HTTP client functionality for making web requests.
+//! Import via `require("@lmb/http")`.
+//!
+//! # Available Methods
+//!
+//! - `fetch(url, options)` - Make an HTTP request and return a response object.
+//!
+//! # Options
+//!
+//! The `fetch` method accepts an optional table with the following fields:
+//! - `method` - HTTP method (GET, POST, PUT, DELETE, etc.). Default: GET.
+//! - `headers` - Table of HTTP headers.
+//! - `body` - Request body string.
+//! - `timeout` - Request timeout (number in seconds or duration string like "5s").
+//!
+//! # Response Object
+//!
+//! The response object has the following properties and methods:
+//! - `status` - HTTP status code (number).
+//! - `ok` - Boolean indicating if status is 2xx.
+//! - `headers` - Table of response headers.
+//! - `text()` - Get response body as string.
+//! - `json()` - Parse response body as JSON.
+//!
+//! # Example
+//!
+//! ```lua
+//! local http = require("@lmb/http")
+//!
+//! -- Simple GET request
+//! local response = http:fetch("https://api.example.com/data")
+//! if response.ok then
+//!     local data = response:json()
+//!     print(data.message)
+//! end
+//!
+//! -- POST request with headers and body
+//! local response = http:fetch("https://api.example.com/submit", {
+//!     method = "POST",
+//!     headers = {
+//!         ["Content-Type"] = "application/json",
+//!         ["Authorization"] = "Bearer token123"
+//!     },
+//!     body = '{"key": "value"}',
+//!     timeout = 30
+//! })
+//!
+//! print(response.status)  -- e.g., 200
+//! print(response:text())  -- Response body as text
+//! ```
+
 use std::{str::FromStr, sync::Arc, time::Duration};
 
 use bon::bon;

--- a/src/fixtures/bindings/crypto-errors.lua
+++ b/src/fixtures/bindings/crypto-errors.lua
@@ -1,0 +1,34 @@
+-- Test crypto error handling
+local crypto = require("@lmb/crypto")
+
+-- Test invalid base64 decode
+local ok, err = pcall(function()
+    crypto.base64_decode("!!!invalid-base64!!!")
+end)
+assert(not ok, "Expected error for invalid base64")
+
+-- Test invalid hex in decrypt
+ok, err = pcall(function()
+    crypto.decrypt("aes-cbc", "not-hex-data", "1234567890123456", "abcdefghijklmnop")
+end)
+assert(not ok, "Expected error for invalid hex data")
+
+-- Test unsupported cipher
+ok, err = pcall(function()
+    crypto.encrypt("unsupported-cipher", "data", "key", "iv")
+end)
+assert(not ok, "Expected error for unsupported cipher")
+
+-- Test unsupported hmac algorithm
+ok, err = pcall(function()
+    crypto.hmac("unsupported", "data", "secret")
+end)
+assert(not ok, "Expected error for unsupported hmac algorithm")
+
+-- Test missing IV for aes-cbc
+ok, err = pcall(function()
+    crypto.encrypt("aes-cbc", "data", "1234567890123456")
+end)
+assert(not ok, "Expected error for missing IV")
+
+return true

--- a/src/fixtures/bindings/crypto/base64-roundtrip.lua
+++ b/src/fixtures/bindings/crypto/base64-roundtrip.lua
@@ -1,0 +1,6 @@
+local crypto = require("@lmb/crypto")
+local original = "Hello, World!"
+local encoded = crypto.base64_encode(original)
+local decoded = crypto.base64_decode(encoded)
+assert(decoded == original, "base64 roundtrip failed")
+return true

--- a/src/fixtures/bindings/crypto/des-cbc.lua
+++ b/src/fixtures/bindings/crypto/des-cbc.lua
@@ -1,0 +1,8 @@
+local crypto = require("@lmb/crypto")
+local key = "12345678"
+local iv = "87654321"
+local plaintext = "testdata"
+local encrypted = crypto.encrypt("des-cbc", plaintext, key, iv)
+local decrypted = crypto.decrypt("des-cbc", encrypted, key, iv)
+assert(decrypted == plaintext, "DES-CBC roundtrip failed")
+return true

--- a/src/fixtures/bindings/crypto/des-ecb.lua
+++ b/src/fixtures/bindings/crypto/des-ecb.lua
@@ -1,0 +1,7 @@
+local crypto = require("@lmb/crypto")
+local key = "12345678"
+local plaintext = "testdata"
+local encrypted = crypto.encrypt("des-ecb", plaintext, key)
+local decrypted = crypto.decrypt("des-ecb", encrypted, key)
+assert(decrypted == plaintext, "DES-ECB roundtrip failed")
+return true

--- a/src/fixtures/bindings/crypto/hash-functions.lua
+++ b/src/fixtures/bindings/crypto/hash-functions.lua
@@ -1,0 +1,10 @@
+local crypto = require("@lmb/crypto")
+-- Test that hash functions return non-empty hex strings
+local data = "test data"
+assert(#crypto.crc32(data) > 0, "crc32 failed")
+assert(#crypto.md5(data) == 32, "md5 failed")
+assert(#crypto.sha1(data) == 40, "sha1 failed")
+assert(#crypto.sha256(data) == 64, "sha256 failed")
+assert(#crypto.sha384(data) == 96, "sha384 failed")
+assert(#crypto.sha512(data) == 128, "sha512 failed")
+return true

--- a/src/fixtures/bindings/globals/sleep-zero.lua
+++ b/src/fixtures/bindings/globals/sleep-zero.lua
@@ -1,0 +1,3 @@
+-- Test that sleep_ms(0) works without error
+sleep_ms(0)
+return true

--- a/src/fixtures/bindings/globals/sleep.lua
+++ b/src/fixtures/bindings/globals/sleep.lua
@@ -1,0 +1,9 @@
+-- Test sleep_ms function
+local start = os.clock()
+sleep_ms(50)
+local elapsed = (os.clock() - start) * 1000
+
+-- Check that at least 40ms has passed (allowing some tolerance)
+assert(elapsed >= 40, "sleep_ms did not wait long enough: " .. elapsed .. "ms")
+
+return true

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -186,6 +186,56 @@ Hello, world!
     }
 }
 
+mod cli {
+    use super::*;
+
+    #[test]
+    fn version() {
+        Command::new(cmd::cargo_bin!("lmb"))
+            .args(["--version"])
+            .assert()
+            .success()
+            .stdout_eq(str![[r#"
+lmb [..]
+
+"#]]);
+    }
+
+    #[test]
+    fn help() {
+        let assert = Command::new(cmd::cargo_bin!("lmb"))
+            .args(["--help"])
+            .assert()
+            .success();
+        let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+        assert!(stdout.contains("Commands:"));
+        assert!(stdout.contains("eval"));
+        assert!(stdout.contains("serve"));
+        assert!(stdout.contains("Options:"));
+    }
+
+    #[test]
+    fn missing_file() {
+        let assert = Command::new(cmd::cargo_bin!("lmb"))
+            .env("NO_COLOR", "true")
+            .args(["eval", "--file", "nonexistent-file.lua"])
+            .assert()
+            .failure();
+        let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+        assert!(stderr.contains("nonexistent-file.lua"));
+    }
+
+    #[test]
+    fn missing_subcommand() {
+        let assert = Command::new(cmd::cargo_bin!("lmb"))
+            .env("NO_COLOR", "true")
+            .assert()
+            .failure();
+        let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+        assert!(stderr.contains("requires a subcommand"));
+    }
+}
+
 mod errors {
     use super::*;
 


### PR DESCRIPTION
## Summary

- Add module-level documentation to `coroutine`, `crypto`, `globals`, and `http` modules with usage examples and security warnings
- Optimize store initialization using `PRAGMA user_version` to track migrations
- Optimize unicode read by holding lock for entire operation
- Add new test coverage for `sleep_ms`, crypto error handling, and CLI error paths
- Add YAML, TOML, and pool concurrent benchmarks
- Extract inline Lua test fixtures to separate files

## Test plan

- [x] All unit tests pass (`cargo test`)
- [x] Clippy checks pass (`cargo clippy`)
- [x] Code formatting verified (`cargo fmt --check`)
- [x] Documentation builds (`cargo doc --no-deps`)
- [x] Benchmarks run successfully (`cargo bench --bench bench`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)