### PR TITLE
feat: add embedded guided tour and improve CLI documentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,6 +265,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -577,7 +601,16 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -588,6 +621,15 @@ checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
  "time",
  "version_check",
+]
+
+[[package]]
+name = "coolor"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "980c2afde4af43d6a05c5be738f9eae595cff86dce1f38f88b95058a98c027f3"
+dependencies = [
+ "crossterm",
 ]
 
 [[package]]
@@ -659,6 +701,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "crokey"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04a63daf06a168535c74ab97cdba3ed4fa5d4f32cb36e437dcceb83d66854b7c"
+dependencies = [
+ "crokey-proc_macros",
+ "crossterm",
+ "once_cell",
+ "serde",
+ "strict",
+]
+
+[[package]]
+name = "crokey-proc_macros"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "847f11a14855fc490bd5d059821895c53e77eeb3c2b73ee3dded7ce77c93b231"
+dependencies = [
+ "crossterm",
+ "proc-macro2",
+ "quote",
+ "strict",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -678,10 +768,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "derive_more 2.1.1",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crunchy"
@@ -798,7 +924,16 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
 dependencies = [
- "derive_more-impl",
+ "derive_more-impl 1.0.0",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl 2.1.1",
 ]
 
 [[package]]
@@ -811,6 +946,19 @@ dependencies = [
  "quote",
  "syn 2.0.114",
  "unicode-xid",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -848,6 +996,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -918,7 +1075,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -963,10 +1120,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fancy-regex"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -997,7 +1175,7 @@ checksum = "40373a6bf84c41c6124c01cbedf5ab53d0d468adf1c0d7efd4c3273531fbb609"
 dependencies = [
  "bytecount",
  "cfg-if",
- "derive_more",
+ "derive_more 1.0.0",
  "full_moon_derive",
  "paste",
  "serde",
@@ -1562,7 +1740,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1683,6 +1861,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1693,6 +1877,12 @@ name = "litemap"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lmb"
@@ -1742,6 +1932,8 @@ dependencies = [
  "sha2",
  "snapbox",
  "string-offsets",
+ "syntect",
+ "termimad",
  "test-case",
  "thiserror",
  "tokio",
@@ -1874,6 +2066,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimad"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8b688969b16915f3ecadc7829d5b7779dee4977e503f767f34136803d5c06f"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1886,6 +2087,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1895,6 +2097,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.1",
 ]
@@ -2229,6 +2432,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "plist"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+dependencies = [
+ "base64",
+ "indexmap 2.11.4",
+ "quick-xml",
+ "serde",
+ "time",
+]
+
+[[package]]
 name = "plotters"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2373,6 +2589,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2424,7 +2649,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2766,6 +2991,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2775,7 +3009,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2863,6 +3097,12 @@ name = "self_cell"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f7d95a54511e0c7be3f51e8867aa8cf35148d7b9445d44de2f943e2b206e749"
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -3049,6 +3289,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3156,6 +3433,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "strict"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f42444fea5b87a39db4218d9422087e66a85d0e7a0963a439b07bcdf91804006"
+
+[[package]]
 name = "string-offsets"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3237,6 +3520,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "syntect"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
+dependencies = [
+ "bincode",
+ "fancy-regex",
+ "flate2",
+ "fnv",
+ "once_cell",
+ "plist",
+ "regex-syntax",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "thiserror",
+ "walkdir",
+ "yaml-rust",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3273,7 +3577,23 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "termimad"
+version = "0.34.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "889a9370996b74cf46016ce35b96c248a9ac36d69aab1d112b3e09bc33affa49"
+dependencies = [
+ "coolor",
+ "crokey",
+ "crossbeam",
+ "lazy-regex",
+ "minimad",
+ "serde",
+ "thiserror",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -3705,6 +4025,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3954,13 +4280,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -4305,6 +4653,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ mlua = { version = "0.11.1", features = [
 ] }
 no_color = "0.2.0"
 parking_lot = "0.12.4"
+pulldown-cmark = "0.13.0"
 reqwest = { version = "0.12.22", default-features = false, features = [
   "charset",
   "http2",
@@ -55,6 +56,8 @@ serde_yaml = "0.9.34"
 sha1 = "0.10.6"
 sha2 = "0.10.9"
 string-offsets = "0.2.0"
+syntect = { version = "5.2", default-features = false, features = ["default-fancy"] }
+termimad = "0.34"
 thiserror = "2.0.12"
 tokio = { version = "1.47.0", default-features = false, features = [
   "fs",
@@ -74,7 +77,6 @@ criterion = { version = "0.7.0", features = ["async_tokio"] }
 curl-parser = "0.6.0"
 full_moon = "2.0.0"
 mockito = "1.7.0"
-pulldown-cmark = "0.13.0"
 snapbox = { version = "0.6.21", features = ["cmd"] }
 test-case = "3.3.1"
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/henry40408/lmb/actions/workflows/ci.yaml/badge.svg)](https://github.com/henry40408/lmb/actions/workflows/ci.yaml)
 [![codecov](https://codecov.io/gh/henry40408/lmb/graph/badge.svg?token=O7WLYVEX0E)](https://codecov.io/gh/henry40408/lmb)
 [![License](https://img.shields.io/github/license/henry40408/lmb)](LICENSE)
-[![Rust](https://img.shields.io/badge/rust-1.85%2B-blue.svg)](https://www.rust-lang.org/)
+[![Rust](https://img.shields.io/badge/rust-1.88%2B-blue.svg)](https://www.rust-lang.org/)
 [![Docker](https://img.shields.io/badge/docker-ghcr.io-blue.svg)](https://ghcr.io/henry40408/lmb)
 [![Casual Maintenance Intended](https://casuallymaintained.tech/badge.svg)](https://casuallymaintained.tech/)
 

--- a/deny.toml
+++ b/deny.toml
@@ -13,4 +13,6 @@ allow = [
 [advisories]
 ignore = [
   { id = "RUSTSEC-2024-0436", reason = "unmaintained paste is not critical" },
+  { id = "RUSTSEC-2024-0320", reason = "unmaintained yaml-rust is not critical" },
+  { id = "RUSTSEC-2025-0141", reason = "unmaintained bincode is not critical" },
 ]

--- a/docs/guided-tour.md
+++ b/docs/guided-tour.md
@@ -269,6 +269,38 @@ end
 return join_all
 ```
 
+#### all_settled
+
+The `all_settled` function waits for all coroutines to complete and returns an array of result objects. Unlike `join_all`, it does not fail if any coroutine fails. Each result object has:
+- `status`: "fulfilled" or "rejected"
+- `value`: The return value (if fulfilled)
+- `reason`: The error (if rejected)
+
+```lua
+--[[
+--name = "Coroutines - all_settled"
+--timeout = 110
+--]]
+function all_settled()
+  local m = require('@lmb/coroutine')
+  local a = coroutine.create(function()
+    return 100
+  end)
+  local b = coroutine.create(function()
+    error("intentional error")
+  end)
+  local results = m.all_settled({ a, b })
+
+  assert(results[1].status == "fulfilled", "Expected first coroutine to be fulfilled")
+  assert(results[1].value == 100, "Expected first coroutine value to be 100")
+
+  assert(results[2].status == "rejected", "Expected second coroutine to be rejected")
+  assert(results[2].reason ~= nil, "Expected second coroutine to have a reason")
+end
+
+return all_settled
+```
+
 #### race
 
 In this example, we demonstrate how to use coroutines to race multiple coroutines against each other and return the result of the first one that finishes.

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,7 +88,7 @@ struct Opts {
     /// Disable store usage
     #[clap(long, action, group = "store_group", env = "NO_STORE")]
     no_store: bool,
-    /// Path to SQLite file for persistent key-value storage
+    /// Path to `SQLite` file for persistent key-value storage
     #[clap(long, value_parser, group = "store_group", env = "STORE_PATH")]
     store_path: Option<PathBuf>,
     /// Script execution timeout (e.g., 30s, 1m). Default: 30s, use 0 for unlimited

--- a/src/tour.rs
+++ b/src/tour.rs
@@ -114,7 +114,10 @@ pub fn find_section(name: &str) -> Option<(Section, String)> {
     for section in &sections {
         if section.title.to_lowercase() == name_lower {
             let content = &GUIDED_TOUR[section.start..section.end];
-            return Some((section.clone(), format!("# {}\n\n{}", section.title, content)));
+            return Some((
+                section.clone(),
+                format!("# {}\n\n{}", section.title, content),
+            ));
         }
     }
 
@@ -122,7 +125,10 @@ pub fn find_section(name: &str) -> Option<(Section, String)> {
     for section in &sections {
         if section.title.to_lowercase().contains(&name_lower) {
             let content = &GUIDED_TOUR[section.start..section.end];
-            return Some((section.clone(), format!("# {}\n\n{}", section.title, content)));
+            return Some((
+                section.clone(),
+                format!("# {}\n\n{}", section.title, content),
+            ));
         }
     }
 
@@ -183,9 +189,7 @@ fn render_plain<W: Write>(writer: &mut W, content: &str) -> io::Result<()> {
                 }
                 write!(writer, " ")?;
             }
-            Event::End(
-                TagEnd::Heading(_) | TagEnd::Paragraph | TagEnd::List(_) | TagEnd::Item,
-            )
+            Event::End(TagEnd::Heading(_) | TagEnd::Paragraph | TagEnd::List(_) | TagEnd::Item)
             | Event::SoftBreak
             | Event::HardBreak => {
                 writeln!(writer)?;

--- a/src/tour.rs
+++ b/src/tour.rs
@@ -1,0 +1,418 @@
+//! Guided tour display module for lmb CLI.
+//!
+//! This module provides functionality to display the guided-tour.md documentation
+//! directly in the terminal with syntax highlighting and proper formatting.
+
+use std::io::{self, Write};
+
+use pulldown_cmark::{Event, Options, Parser, Tag, TagEnd};
+use syntect::{
+    easy::HighlightLines,
+    highlighting::{Style, ThemeSet},
+    parsing::SyntaxSet,
+    util::as_24_bit_terminal_escaped,
+};
+use termimad::{MadSkin, crossterm::style::Color};
+
+/// Embedded guided tour documentation
+const GUIDED_TOUR: &str = include_str!("../docs/guided-tour.md");
+
+/// Color mode for terminal output
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ColorMode {
+    /// 24-bit RGB true color (default for modern terminals)
+    TrueColor,
+    /// No color output
+    None,
+}
+
+impl ColorMode {
+    /// Detect color mode based on environment
+    pub fn detect(no_color: bool) -> Self {
+        if no_color || std::env::var("NO_COLOR").is_ok() {
+            ColorMode::None
+        } else {
+            ColorMode::TrueColor
+        }
+    }
+}
+
+/// Section information extracted from the markdown
+#[derive(Debug, Clone)]
+pub struct Section {
+    /// Section title (heading text)
+    pub title: String,
+    /// Heading level (1-6)
+    pub level: u8,
+    /// Start byte offset in the source
+    pub start: usize,
+    /// End byte offset in the source
+    pub end: usize,
+}
+
+/// Extract all sections from the guided tour markdown
+fn extract_sections(source: &str) -> Vec<Section> {
+    let mut sections = Vec::new();
+    let parser = Parser::new_ext(source, Options::all());
+
+    let mut current_heading: Option<(String, u8, usize)> = None;
+    let mut in_heading = false;
+    let mut heading_text = String::new();
+    let mut heading_level = 0u8;
+
+    for (event, range) in parser.into_offset_iter() {
+        match event {
+            Event::Start(Tag::Heading { level, .. }) => {
+                // Close previous section
+                if let Some((title, lvl, start)) = current_heading.take() {
+                    sections.push(Section {
+                        title,
+                        level: lvl,
+                        start,
+                        end: range.start,
+                    });
+                }
+                in_heading = true;
+                heading_level = level as u8;
+                heading_text.clear();
+            }
+            Event::End(TagEnd::Heading(_)) => {
+                in_heading = false;
+                current_heading = Some((heading_text.clone(), heading_level, range.start));
+            }
+            Event::Text(text) if in_heading => {
+                heading_text.push_str(&text);
+            }
+            _ => {}
+        }
+    }
+
+    // Close last section
+    if let Some((title, level, start)) = current_heading {
+        sections.push(Section {
+            title,
+            level,
+            start,
+            end: source.len(),
+        });
+    }
+
+    sections
+}
+
+/// List all available sections
+pub fn list_sections() -> Vec<Section> {
+    extract_sections(GUIDED_TOUR)
+}
+
+/// Find a section by name (case-insensitive partial match)
+pub fn find_section(name: &str) -> Option<(Section, String)> {
+    let sections = extract_sections(GUIDED_TOUR);
+    let name_lower = name.to_lowercase();
+
+    // First try exact match
+    for section in &sections {
+        if section.title.to_lowercase() == name_lower {
+            let content = &GUIDED_TOUR[section.start..section.end];
+            return Some((section.clone(), format!("# {}\n\n{}", section.title, content)));
+        }
+    }
+
+    // Then try partial match
+    for section in &sections {
+        if section.title.to_lowercase().contains(&name_lower) {
+            let content = &GUIDED_TOUR[section.start..section.end];
+            return Some((section.clone(), format!("# {}\n\n{}", section.title, content)));
+        }
+    }
+
+    None
+}
+
+/// Render markdown with syntax highlighting for code blocks
+pub fn render(content: &str, color_mode: ColorMode) -> anyhow::Result<()> {
+    let stdout = io::stdout();
+    let mut handle = stdout.lock();
+
+    if color_mode == ColorMode::None {
+        // Plain text output without colors
+        render_plain(&mut handle, content)?;
+    } else {
+        // Colored output with syntax highlighting
+        render_colored(&mut handle, content)?;
+    }
+
+    Ok(())
+}
+
+/// Render plain text without colors
+fn render_plain<W: Write>(writer: &mut W, content: &str) -> io::Result<()> {
+    let parser = Parser::new_ext(content, Options::all());
+    let mut in_code_block = false;
+    let mut code_content = String::new();
+
+    for event in parser {
+        match event {
+            Event::Start(Tag::CodeBlock(_)) => {
+                in_code_block = true;
+                code_content.clear();
+                writeln!(writer)?;
+            }
+            Event::End(TagEnd::CodeBlock) => {
+                in_code_block = false;
+                // Indent code block
+                for line in code_content.lines() {
+                    writeln!(writer, "    {line}")?;
+                }
+                writeln!(writer)?;
+            }
+            Event::Text(text) => {
+                if in_code_block {
+                    code_content.push_str(&text);
+                } else {
+                    write!(writer, "{text}")?;
+                }
+            }
+            Event::Code(code) => {
+                write!(writer, "`{code}`")?;
+            }
+            Event::Start(Tag::Heading { level, .. }) => {
+                writeln!(writer)?;
+                for _ in 0..level as usize {
+                    write!(writer, "#")?;
+                }
+                write!(writer, " ")?;
+            }
+            Event::End(TagEnd::Heading(_)) => {
+                writeln!(writer)?;
+            }
+            Event::Start(Tag::Paragraph) => {}
+            Event::End(TagEnd::Paragraph) => {
+                writeln!(writer)?;
+            }
+            Event::Start(Tag::List(_)) => {}
+            Event::End(TagEnd::List(_)) => {
+                writeln!(writer)?;
+            }
+            Event::Start(Tag::Item) => {
+                write!(writer, "  - ")?;
+            }
+            Event::End(TagEnd::Item) => {
+                writeln!(writer)?;
+            }
+            Event::SoftBreak | Event::HardBreak => {
+                writeln!(writer)?;
+            }
+            Event::Start(Tag::Link { dest_url, .. }) => {
+                write!(writer, "[")?;
+                // Store URL for later
+                let _ = dest_url;
+            }
+            Event::End(TagEnd::Link) => {
+                write!(writer, "]")?;
+            }
+            _ => {}
+        }
+    }
+
+    writer.flush()
+}
+
+/// Render with colors and syntax highlighting
+fn render_colored<W: Write>(writer: &mut W, content: &str) -> io::Result<()> {
+    let ss = SyntaxSet::load_defaults_newlines();
+    let ts = ThemeSet::load_defaults();
+    let theme = &ts.themes["base16-ocean.dark"];
+
+    let parser = Parser::new_ext(content, Options::all());
+    let mut in_code_block = false;
+    let mut code_content = String::new();
+    let mut code_lang = String::new();
+
+    let _skin = create_skin();
+
+    for event in parser {
+        match event {
+            Event::Start(Tag::CodeBlock(kind)) => {
+                in_code_block = true;
+                code_content.clear();
+                code_lang = match kind {
+                    pulldown_cmark::CodeBlockKind::Fenced(lang) => lang.to_string(),
+                    pulldown_cmark::CodeBlockKind::Indented => String::new(),
+                };
+                writeln!(writer)?;
+            }
+            Event::End(TagEnd::CodeBlock) => {
+                in_code_block = false;
+
+                // Determine syntax for highlighting
+                let syntax = if code_lang == "luau" || code_lang == "lua" {
+                    ss.find_syntax_by_extension("lua")
+                } else if code_lang.is_empty() {
+                    None
+                } else {
+                    ss.find_syntax_by_extension(&code_lang)
+                        .or_else(|| ss.find_syntax_by_name(&code_lang))
+                };
+
+                if let Some(syntax) = syntax {
+                    let mut highlighter = HighlightLines::new(syntax, theme);
+                    for line in code_content.lines() {
+                        let ranges: Vec<(Style, &str)> =
+                            highlighter.highlight_line(line, &ss).unwrap_or_default();
+                        let escaped = as_24_bit_terminal_escaped(&ranges[..], false);
+                        writeln!(writer, "    {escaped}\x1b[0m")?;
+                    }
+                } else {
+                    // No syntax found, render as plain code
+                    for line in code_content.lines() {
+                        writeln!(writer, "    {line}")?;
+                    }
+                }
+                writeln!(writer)?;
+            }
+            Event::Text(text) => {
+                if in_code_block {
+                    code_content.push_str(&text);
+                } else {
+                    write!(writer, "{text}")?;
+                }
+            }
+            Event::Code(code) => {
+                // Inline code with background
+                write!(writer, "\x1b[48;5;238m{code}\x1b[0m")?;
+            }
+            Event::Start(Tag::Heading { level, .. }) => {
+                writeln!(writer)?;
+                // Color headings based on level
+                let color_code = match level {
+                    pulldown_cmark::HeadingLevel::H1 => "\x1b[1;36m", // Bold cyan
+                    pulldown_cmark::HeadingLevel::H2 => "\x1b[1;33m", // Bold yellow
+                    pulldown_cmark::HeadingLevel::H3 => "\x1b[1;32m", // Bold green
+                    _ => "\x1b[1;37m",                                // Bold white
+                };
+                write!(writer, "{color_code}")?;
+                for _ in 0..level as usize {
+                    write!(writer, "#")?;
+                }
+                write!(writer, " ")?;
+            }
+            Event::End(TagEnd::Heading(_)) => {
+                writeln!(writer, "\x1b[0m")?;
+            }
+            Event::Start(Tag::Paragraph) => {}
+            Event::End(TagEnd::Paragraph) => {
+                writeln!(writer)?;
+            }
+            Event::Start(Tag::List(_)) => {}
+            Event::End(TagEnd::List(_)) => {
+                writeln!(writer)?;
+            }
+            Event::Start(Tag::Item) => {
+                write!(writer, "  \x1b[33m-\x1b[0m ")?;
+            }
+            Event::End(TagEnd::Item) => {
+                writeln!(writer)?;
+            }
+            Event::SoftBreak | Event::HardBreak => {
+                writeln!(writer)?;
+            }
+            Event::Start(Tag::Link { dest_url, .. }) => {
+                write!(writer, "\x1b[4;34m")?; // Underline blue
+                let _ = dest_url;
+            }
+            Event::End(TagEnd::Link) => {
+                write!(writer, "\x1b[0m")?;
+            }
+            Event::Start(Tag::Strong) => {
+                write!(writer, "\x1b[1m")?; // Bold
+            }
+            Event::End(TagEnd::Strong) => {
+                write!(writer, "\x1b[0m")?;
+            }
+            Event::Start(Tag::Emphasis) => {
+                write!(writer, "\x1b[3m")?; // Italic
+            }
+            Event::End(TagEnd::Emphasis) => {
+                write!(writer, "\x1b[0m")?;
+            }
+            _ => {}
+        }
+    }
+
+    writer.flush()
+}
+
+/// Create a termimad skin for rendering (kept for potential future use)
+fn create_skin() -> MadSkin {
+    let mut skin = MadSkin::default();
+    skin.headers[0].set_fg(Color::Cyan);
+    skin.headers[1].set_fg(Color::Yellow);
+    skin.headers[2].set_fg(Color::Green);
+    skin.bold.set_fg(Color::White);
+    skin.italic.set_fg(Color::Magenta);
+    skin.code_block.set_bg(Color::AnsiValue(235));
+    skin
+}
+
+/// Display the full guided tour
+pub fn display_tour(color_mode: ColorMode) -> anyhow::Result<()> {
+    render(GUIDED_TOUR, color_mode)
+}
+
+/// Display a specific section of the guided tour
+pub fn display_section(section_name: &str, color_mode: ColorMode) -> anyhow::Result<()> {
+    match find_section(section_name) {
+        Some((_, content)) => render(&content, color_mode),
+        None => {
+            eprintln!("Section '{}' not found.", section_name);
+            eprintln!("Use 'lmb tour --list' to see available sections.");
+            std::process::exit(1);
+        }
+    }
+}
+
+/// Print the list of available sections
+pub fn print_section_list() {
+    let sections = list_sections();
+
+    println!("Available sections in the guided tour:\n");
+
+    for section in sections {
+        let indent = "  ".repeat((section.level - 1) as usize);
+        println!("{indent}{}", section.title);
+    }
+
+    println!("\nUse 'lmb tour -s <section>' to view a specific section.");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_sections() {
+        let sections = extract_sections(GUIDED_TOUR);
+        assert!(!sections.is_empty());
+        assert_eq!(sections[0].title, "Guided tour");
+    }
+
+    #[test]
+    fn test_find_section() {
+        let result = find_section("hello");
+        assert!(result.is_some());
+        let (section, _) = result.expect("Section should be found");
+        assert!(section.title.to_lowercase().contains("hello"));
+    }
+
+    #[test]
+    fn test_find_section_crypto() {
+        let result = find_section("crypto");
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn test_color_mode_detect() {
+        assert_eq!(ColorMode::detect(true), ColorMode::None);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `lmb tour` subcommand to display guided-tour.md directly in terminal with syntax highlighting
- Improve CLI help messages with detailed descriptions and usage examples
- Update Rust version badge and add `all_settled` coroutine documentation

## Features

### Guided Tour Command
```bash
lmb tour                 # Display full guided tour
lmb tour | less -R       # Use with pager
lmb tour --list          # List all sections
lmb tour -s crypto       # Display specific section
lmb --no-color tour      # Plain text mode
```

### CLI Help Improvements
- Added `--after-help` examples for `eval`, `serve`, and `tour` commands
- Added detailed `--long-about` description for the main command

## Test plan

- [x] `cargo build` compiles successfully
- [x] `cargo test tour::` passes all tests
- [x] `lmb tour` displays colored output with syntax highlighting
- [x] `lmb tour --list` shows all sections
- [x] `lmb tour -s crypto` displays specific section
- [x] `lmb --no-color tour` works without colors
- [x] `lmb tour | less -R` works with pager

🤖 Generated with [Claude Code](https://claude.com/claude-code)