### PR TITLE
docs: fix documentation issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/henry40408/lmb/actions/workflows/ci.yaml/badge.svg)](https://github.com/henry40408/lmb/actions/workflows/ci.yaml)
 [![codecov](https://codecov.io/gh/henry40408/lmb/graph/badge.svg?token=O7WLYVEX0E)](https://codecov.io/gh/henry40408/lmb)
-[![License](https://img.shields.io/github/license/henry40408/lmb)](LICENSE)
+[![License](https://img.shields.io/github/license/henry40408/lmb)](LICENSE.txt)
 [![Rust](https://img.shields.io/badge/rust-1.88%2B-blue.svg)](https://www.rust-lang.org/)
 [![Docker](https://img.shields.io/badge/docker-ghcr.io-blue.svg)](https://ghcr.io/henry40408/lmb)
 [![Casual Maintenance Intended](https://casuallymaintained.tech/badge.svg)](https://casuallymaintained.tech/)

--- a/docs/guided-tour.md
+++ b/docs/guided-tour.md
@@ -466,7 +466,8 @@ In this section, we demonstrate how to make HTTP requests using the `@lmb/http` 
 ```lua
 --[[
 --name = "HTTP"
---state = {}
+--# NOTE: The url is a placeholder; it will be overridden by the test harness.
+--state = { url = "http://localhost:8080" }
 --]]
 function http_get(ctx)
   local http = require("@lmb/http")

--- a/docs/guided-tour.md
+++ b/docs/guided-tour.md
@@ -308,6 +308,7 @@ In this example, we demonstrate how to use coroutines to race multiple coroutine
 ```lua
 --[[
 --name = "Coroutines - race"
+--timeout = 10
 --]]
 function race()
   local m = require('@lmb/coroutine')


### PR DESCRIPTION
## Summary
- Fix LICENSE link in README (LICENSE → LICENSE.txt)
- Clarify HTTP example state with placeholder URL and `--#` comment
- Add missing timeout to race coroutine example

## Test plan
- [x] `cargo test --test guided_tour` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)