### PR TITLE
fix: improve error handling and prevent information leaks

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -86,7 +86,7 @@ where
 }
 
 /// Renders a report to a string using the graphical report handler.
-pub fn render_report<W>(writer: &mut W, report: &Report)
+pub fn render_report<W>(writer: &mut W, report: &Report) -> std::fmt::Result
 where
     W: std::fmt::Write,
 {
@@ -95,7 +95,5 @@ where
     } else {
         GraphicalTheme::ascii()
     };
-    GraphicalReportHandler::new_themed(theme)
-        .render_report(writer, report.as_ref())
-        .expect("failed to render report");
+    GraphicalReportHandler::new_themed(theme).render_report(writer, report.as_ref())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -364,7 +364,10 @@ impl Runner {
                         .build());
                 }
             } else {
-                unreachable!()
+                debug_assert!(false, "pcall should always return an error on failure");
+                return Ok(invoked
+                    .result(Err(LmbError::Lua(LuaError::runtime("pcall failed"))))
+                    .build());
             }
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -216,7 +216,7 @@ async fn report_error(file: &Input, source: &Option<String>, e: &LmbError) -> an
     match report {
         ErrorReport::Report(report) => {
             let mut s = String::new();
-            render_report(&mut s, &report);
+            render_report(&mut s, &report)?;
             io::stderr().write_all(s.as_bytes())?;
             io::stderr().flush()?;
         }

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -42,11 +42,9 @@ pub(crate) struct AppError(anyhow::Error);
 
 impl IntoResponse for AppError {
     fn into_response(self) -> axum::response::Response {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Something went wrong {}", self.0),
-        )
-            .into_response()
+        // Log error internally, don't expose details to clients
+        error!("Internal error: {:?}", self.0);
+        (StatusCode::INTERNAL_SERVER_ERROR, "Internal server error").into_response()
     }
 }
 


### PR DESCRIPTION
## Summary

- Prevent sensitive error details from leaking to HTTP clients in serve mode
- Replace `.expect()` with proper error propagation in `render_report`
- Replace `unreachable!()` with `debug_assert!` and safe fallback for pcall error handling

## Test plan

- [x] All existing tests pass
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)