### PR TITLE
feat: add `@lmb/logging` module with standard log levels

### DIFF
--- a/docs/guided-tour.md
+++ b/docs/guided-tour.md
@@ -327,6 +327,35 @@ end
 return race
 ```
 
+### Logging
+
+The `@lmb/logging` module provides standard log-level functions that integrate with the Rust `tracing` framework. Each method accepts variadic arguments, which are converted to strings and joined with tab characters (matching Lua `print()` convention). Tables are automatically serialized to JSON.
+
+Available log levels: `error`, `warn`, `info`, `debug`, `trace`.
+
+```lua
+--[[
+--name = "Logging"
+--]]
+function logging()
+  local log = require("@lmb/logging")
+
+  -- Log at different levels
+  log.error("something went wrong")
+  log.warn("deprecated feature used")
+  log.info("server started", "port", 8080)
+  log.debug("processing request", { method = "GET", path = "/" })
+  log.trace("detailed step")
+
+  -- Tables are serialized to JSON
+  log.info("config", { host = "localhost", port = 3000 })
+end
+
+return logging
+```
+
+Use `RUST_LOG=lmb::lua=debug` to control the log level for Lua scripts independently from the rest of the application.
+
 ### Cryptography
 
 In this section, we demonstrate various cryptographic functions such as encoding, hashing, HMAC, and encryption/decryption. These functions are essential for secure data handling and communication.

--- a/src/bindings/logging.rs
+++ b/src/bindings/logging.rs
@@ -78,6 +78,7 @@ impl LuaUserData for LoggingBinding {
 
 #[cfg(test)]
 mod tests {
+    use mlua::prelude::*;
     use tokio::io::empty;
 
     use crate::Runner;
@@ -87,5 +88,17 @@ mod tests {
         let source = include_str!("../fixtures/bindings/logging.lua");
         let runner = Runner::builder(source, empty()).build().unwrap();
         runner.invoke().call().await.unwrap().result.unwrap();
+    }
+
+    #[test]
+    fn test_lua_value_to_string_error() {
+        let lua = Lua::new();
+        let err = LuaError::runtime("test error");
+        let value = LuaValue::Error(Box::new(err));
+        let result = super::lua_value_to_string(&lua, value).unwrap();
+        assert!(
+            result.contains("test error"),
+            "Expected error message, got: {result}"
+        );
     }
 }

--- a/src/bindings/logging.rs
+++ b/src/bindings/logging.rs
@@ -1,0 +1,91 @@
+//! Logging binding module.
+//!
+//! This module provides standard log-level functions for Lua scripts.
+//! Import via `require("@lmb/logging")`.
+//!
+//! # Available Methods
+//!
+//! - `error(...)` - Log at ERROR level.
+//! - `warn(...)` - Log at WARN level.
+//! - `info(...)` - Log at INFO level.
+//! - `debug(...)` - Log at DEBUG level.
+//! - `trace(...)` - Log at TRACE level.
+//!
+//! Each method accepts variadic arguments. Multiple arguments are converted
+//! to strings and joined with tab characters (matching Lua `print()` convention).
+//! Tables are serialized to JSON.
+//!
+//! # Example
+//!
+//! ```lua
+//! local log = require("@lmb/logging")
+//!
+//! log.info("server started", "port", 8080)
+//! log.debug("request", { method = "GET", path = "/" })
+//! log.error("something went wrong")
+//! ```
+
+use mlua::prelude::*;
+
+fn lua_value_to_string(vm: &Lua, value: LuaValue) -> LuaResult<String> {
+    match value {
+        LuaValue::Nil => Ok("nil".to_string()),
+        LuaValue::Boolean(b) => Ok(b.to_string()),
+        LuaValue::Integer(n) => Ok(n.to_string()),
+        LuaValue::Number(n) => Ok(n.to_string()),
+        LuaValue::String(s) => Ok(s.to_string_lossy()),
+        LuaValue::Table(_) => {
+            let json: serde_json::Value = vm.from_value(LuaValue::Table(
+                value.as_table().expect("checked above").clone(),
+            ))?;
+            Ok(json.to_string())
+        }
+        LuaValue::Error(e) => Ok(e.to_string()),
+        other => Ok(format!("<{}>", other.type_name())),
+    }
+}
+
+fn lua_values_to_message(vm: &Lua, values: LuaMultiValue) -> LuaResult<String> {
+    let parts: Vec<String> = values
+        .into_iter()
+        .map(|v| lua_value_to_string(vm, v))
+        .collect::<LuaResult<_>>()?;
+    Ok(parts.join("\t"))
+}
+
+macro_rules! add_log_method {
+    ($methods:expr, $level:ident) => {
+        $methods.add_function(stringify!($level), |vm, values: LuaMultiValue| {
+            let message = lua_values_to_message(&vm, values)?;
+            tracing::$level!(target: "lmb::lua", "{message}");
+            Ok(())
+        });
+    };
+}
+
+/// Logging binding that exposes standard log levels to Lua.
+pub(crate) struct LoggingBinding;
+
+impl LuaUserData for LoggingBinding {
+    fn add_methods<M: LuaUserDataMethods<Self>>(methods: &mut M) {
+        add_log_method!(methods, error);
+        add_log_method!(methods, warn);
+        add_log_method!(methods, info);
+        add_log_method!(methods, debug);
+        add_log_method!(methods, trace);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::io::empty;
+
+    use crate::Runner;
+
+    #[tokio::test]
+    async fn test_logging() {
+        let source = include_str!("../fixtures/bindings/logging.lua");
+        let runner = Runner::builder(source, empty()).build().unwrap();
+        runner.invoke().call().await.unwrap().result.unwrap();
+    }
+}

--- a/src/bindings/mod.rs
+++ b/src/bindings/mod.rs
@@ -39,6 +39,7 @@ pub(crate) mod http;
 pub(crate) mod io;
 pub(crate) mod json;
 pub(crate) mod json_path;
+pub(crate) mod logging;
 pub(crate) mod store;
 pub(crate) mod toml;
 pub(crate) mod yaml;

--- a/src/fixtures/bindings/logging.lua
+++ b/src/fixtures/bindings/logging.lua
@@ -28,6 +28,12 @@ function test_logging()
 
   -- Test mixed types
   log.info("mixed", 42, true, nil, { a = 1 })
+
+  -- Test function value (covers the fallback type name branch)
+  log.info("function:", function() end)
+
+  -- Test thread value
+  log.info("thread:", coroutine.create(function() end))
 end
 
 return test_logging

--- a/src/fixtures/bindings/logging.lua
+++ b/src/fixtures/bindings/logging.lua
@@ -1,0 +1,33 @@
+function test_logging()
+  local log = require("@lmb/logging")
+
+  -- Test all 5 log levels with a simple string
+  log.error("error message")
+  log.warn("warn message")
+  log.info("info message")
+  log.debug("debug message")
+  log.trace("trace message")
+
+  -- Test variadic arguments (tab-separated like print())
+  log.info("hello", "world", 42)
+
+  -- Test table serialization to JSON
+  log.info("table", { key = "value", nested = { a = 1 } })
+
+  -- Test nil argument
+  log.info("nil value:", nil)
+
+  -- Test no arguments
+  log.info()
+
+  -- Test numbers
+  log.info(1, 2.5, 3)
+
+  -- Test boolean
+  log.info(true, false)
+
+  -- Test mixed types
+  log.info("mixed", 42, true, nil, { a = 1 })
+end
+
+return test_logging

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,6 +244,7 @@ impl Runner {
             )?;
             vm.register_module("@lmb/json", bindings::json::JsonBinding {})?;
             vm.register_module("@lmb/json-path", bindings::json_path::JsonPathBinding {})?;
+            vm.register_module("@lmb/logging", bindings::logging::LoggingBinding {})?;
             vm.register_module("@lmb/toml", bindings::toml::TomlBinding {})?;
             vm.register_module("@lmb/yaml", bindings::yaml::YamlBinding {})?;
         }


### PR DESCRIPTION
## Summary

- Add `@lmb/logging` module exposing `error`, `warn`, `info`, `debug`, and `trace` log functions to Lua scripts via the `tracing` framework
- Use target `lmb::lua` for independent log filtering (e.g., `RUST_LOG=lmb::lua=debug`)
- Variadic arguments are tab-separated (matching Lua `print()` convention), tables are serialized to JSON
- Add guided tour documentation section with examples

Closes #45

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy` passes (no new warnings)
- [x] `cargo test` — all 170+ tests pass, including new `test_logging` and `test_guided_tour`

🤖 Generated with [Claude Code](https://claude.com/claude-code)