### PR TITLE
feat: add `parse_path` to `@lmb/http` for URL path parameter extraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1925,6 +1925,7 @@ dependencies = [
  "hmac",
  "jiff",
  "lazy-regex",
+ "matchit",
  "md-5",
  "miette",
  "mlua",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ hex = "0.4.3"
 hmac = "0.12.1"
 jiff = { version = "0.2.15", default-features = false, features = ["std"] }
 lazy-regex = "3.4.1"
+matchit = "0.8"
 md-5 = "0.10.6"
 miette = { version = "7.6.0", default-features = false, features = ["fancy"] }
 mlua = { version = "0.11.1", features = [

--- a/src/bindings/http.rs
+++ b/src/bindings/http.rs
@@ -222,23 +222,20 @@ impl LuaUserData for HttpBinding {
                 })
             },
         );
-        methods.add_function(
-            "parse_path",
-            |vm, (path, pattern): (String, String)| {
-                let mut router = Router::new();
-                router.insert(&pattern, ()).into_lua_err()?;
-                match router.at(&path) {
-                    Ok(matched) => {
-                        let table = vm.create_table()?;
-                        for (key, value) in matched.params.iter() {
-                            table.set(key, value)?;
-                        }
-                        Ok(LuaValue::Table(table))
+        methods.add_function("parse_path", |vm, (path, pattern): (String, String)| {
+            let mut router = Router::new();
+            router.insert(&pattern, ()).into_lua_err()?;
+            match router.at(&path) {
+                Ok(matched) => {
+                    let table = vm.create_table()?;
+                    for (key, value) in matched.params.iter() {
+                        table.set(key, value)?;
                     }
-                    Err(_) => Ok(LuaNil),
+                    Ok(LuaValue::Table(table))
                 }
-            },
-        );
+                Err(_) => Ok(LuaNil),
+            }
+        });
     }
 }
 

--- a/src/bindings/http.rs
+++ b/src/bindings/http.rs
@@ -6,6 +6,7 @@
 //! # Available Methods
 //!
 //! - `fetch(url, options)` - Make an HTTP request and return a response object.
+//! - `parse_path(path, pattern)` - Extract path parameters from a URL path using a pattern.
 //!
 //! # Options
 //!
@@ -23,6 +24,15 @@
 //! - `headers` - Table of response headers.
 //! - `text()` - Get response body as string.
 //! - `json()` - Parse response body as JSON.
+//!
+//! # `parse_path`
+//!
+//! Extracts named parameters from a URL path by matching it against a pattern.
+//! Returns a table of parameter key-value pairs on match, or `nil` if the path
+//! does not match the pattern.
+//!
+//! Pattern syntax uses `{name}` for named parameters and `{*name}` for catch-all
+//! parameters (powered by the `matchit` crate).
 //!
 //! # Example
 //!
@@ -49,12 +59,17 @@
 //!
 //! print(response.status)  -- e.g., 200
 //! print(response:text())  -- Response body as text
+//!
+//! -- Parse path parameters
+//! local params = http.parse_path("/users/42", "/users/{id}")
+//! print(params.id)  -- "42"
 //! ```
 
 use std::{str::FromStr, sync::Arc, time::Duration};
 
 use bon::bon;
 use bytes::BytesMut;
+use matchit::Router;
 use mlua::prelude::*;
 use reqwest::{
     Method, StatusCode,
@@ -207,6 +222,23 @@ impl LuaUserData for HttpBinding {
                 })
             },
         );
+        methods.add_function(
+            "parse_path",
+            |vm, (path, pattern): (String, String)| {
+                let mut router = Router::new();
+                router.insert(&pattern, ()).into_lua_err()?;
+                match router.at(&path) {
+                    Ok(matched) => {
+                        let table = vm.create_table()?;
+                        for (key, value) in matched.params.iter() {
+                            table.set(key, value)?;
+                        }
+                        Ok(LuaValue::Table(table))
+                    }
+                    Err(_) => Ok(LuaNil),
+                }
+            },
+        );
     }
 }
 
@@ -263,5 +295,12 @@ mod tests {
         assert_eq!(json!({"a":1}), result.result.unwrap());
 
         mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_parse_path() {
+        let source = include_str!("../fixtures/bindings/http-parse-path.lua");
+        let runner = Runner::builder(source, empty()).build().unwrap();
+        runner.invoke().call().await.unwrap().result.unwrap();
     }
 }

--- a/src/fixtures/bindings/http-parse-path.lua
+++ b/src/fixtures/bindings/http-parse-path.lua
@@ -1,0 +1,44 @@
+function test_parse_path()
+  local http = require("@lmb/http")
+
+  -- Single parameter extraction
+  local params = http.parse_path("/users/42", "/users/{id}")
+  assert(params.id == "42", "Expected id '42', got " .. tostring(params.id))
+
+  -- Multiple parameter extraction
+  params = http.parse_path("/users/42/posts/99", "/users/{user_id}/posts/{post_id}")
+  assert(params.user_id == "42", "Expected user_id '42', got " .. tostring(params.user_id))
+  assert(params.post_id == "99", "Expected post_id '99', got " .. tostring(params.post_id))
+
+  -- Exact static path match (no parameters)
+  params = http.parse_path("/health", "/health")
+  assert(params ~= nil, "Expected table for exact match, got nil")
+
+  -- Non-matching path returns nil
+  params = http.parse_path("/other/path", "/users/{id}")
+  assert(params == nil, "Expected nil for non-matching path")
+
+  -- Different segment count returns nil
+  params = http.parse_path("/users/42/extra", "/users/{id}")
+  assert(params == nil, "Expected nil for different segment count")
+
+  -- Empty path
+  params = http.parse_path("", "/users/{id}")
+  assert(params == nil, "Expected nil for empty path")
+
+  -- Root path
+  params = http.parse_path("/", "/")
+  assert(params ~= nil, "Expected table for root path match, got nil")
+
+  -- Parameter value with special characters (hyphens)
+  params = http.parse_path("/items/my-cool-item", "/items/{slug}")
+  assert(params.slug == "my-cool-item", "Expected slug 'my-cool-item', got " .. tostring(params.slug))
+
+  -- Catch-all parameter
+  params = http.parse_path("/files/docs/readme.md", "/files/{*rest}")
+  assert(params.rest == "docs/readme.md", "Expected rest 'docs/readme.md', got " .. tostring(params.rest))
+
+  return "ok"
+end
+
+return test_parse_path


### PR DESCRIPTION
## Summary

- Add `parse_path(path, pattern)` function to `@lmb/http` that extracts named parameters from URL paths using the `matchit` crate
- Returns a table of key-value pairs on match, or `nil` if the path does not match
- Supports named parameters (`{name}`), catch-all parameters (`{*name}`), and static paths

Closes #46

## Test plan

- [x] `cargo test test_parse_path` — dedicated test covering 9 scenarios (single/multiple params, static match, non-match, different segment count, empty path, root path, special chars, catch-all)
- [x] `cargo test` — all 172 unit tests + integration tests pass, no regressions
- [x] `cargo clippy` — no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)