### PR TITLE
perf: optimize hot paths for ~30-70% benchmark improvement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -889,20 +889,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashmap"
-version = "6.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1389,12 +1375,6 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -1915,7 +1895,6 @@ dependencies = [
  "criterion",
  "crypto-common",
  "curl-parser",
- "dashmap",
  "deadpool",
  "des",
  "ecb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ clap = { version = "4.5.41", features = ["derive", "env"] }
 clio = { version = "0.3.5", features = ["clap-parse"] }
 crc32fast = "1.5.0"
 crypto-common = "0.1.6"
-dashmap = "6.1.0"
 deadpool = "0.12.3"
 des = "0.8.1"
 ecb = "0.1.2"
@@ -94,6 +93,11 @@ opt-level = "z"
 # https://github.com/mlua-rs/mlua/issues/350#issuecomment-1870522709
 #panic = "abort"
 strip = true
+
+[profile.bench]
+inherits = "release"
+opt-level = 3
+strip = false
 
 [[bench]]
 name = "bench"

--- a/src/store.rs
+++ b/src/store.rs
@@ -32,7 +32,7 @@ impl Store {
     /// Retrieves a value from the store by key
     pub fn get<S: AsRef<str>>(&self, key: S) -> LmbResult<Option<Value>> {
         let conn = self.inner.lock();
-        let mut stmt = conn.prepare(SQL_GET)?;
+        let mut stmt = conn.prepare_cached(SQL_GET)?;
         let mut rows = stmt.query(params![key.as_ref()])?;
         if let Some(row) = rows.next()? {
             let value: Vec<u8> = row.get(0)?;
@@ -48,7 +48,8 @@ impl Store {
         let conn = self.inner.lock();
         let key = key.as_ref();
         let serialized = rmp_serde::to_vec(&value)?;
-        conn.execute(SQL_PUT, params![key, serialized])?;
+        conn.prepare_cached(SQL_PUT)?
+            .execute(params![key, serialized])?;
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

- Add `[profile.bench]` with `opt-level = 3` so benchmarks compile for speed instead of inheriting `opt-level = "z"` (size) from the release profile
- Split interrupt handler to skip `elapsed()` check when no timeout is set
- Eliminate `values[1..].to_vec()` allocation in `invoke()` using in-place `remove(0)`
- Use `prepare_cached()` instead of `prepare()` for SQLite statements in store operations
- Replace `DashMap` with `parking_lot::Mutex<HashMap>` for store snapshots (single-threaded access only); remove `dashmap` dependency

### Benchmark results

| Benchmark | Before | After | Improvement |
|-----------|--------|-------|-------------|
| baseline | 1.00 µs | 738 ns | **26%** |
| baseline expr | 1.00 µs | 742 ns | **26%** |
| add | 1.28 µs | 895 ns | **30%** |
| read | 1.90 µs | 1.42 µs | **25%** |
| read unicode | 2.03 µs | 1.47 µs | **28%** |
| json encode decode | 5.38 µs | 3.84 µs | **29%** |
| toml encode decode | 9.47 µs | 6.58 µs | **31%** |
| store set get | 15.85 µs | 5.32 µs | **66%** |
| crypto | 17.86 µs | 10.88 µs | **39%** |
| yaml encode decode | 25.66 µs | 14.18 µs | **45%** |
| pool concurrent | 28.12 µs | 22.57 µs | **20%** |
| store update | 40.52 µs | 12.21 µs | **70%** |

## Test plan

- [x] All 192 tests pass (`cargo test`)
- [x] Clippy clean (`cargo clippy --all-targets`)
- [x] Format clean (`cargo fmt --check`)
- [x] Benchmarks run successfully with improved results

🤖 Generated with [Claude Code](https://claude.com/claude-code)