### PR TITLE
feat: add @lmb/fs module with permission-controlled file system access

### DIFF
--- a/src/bindings/fs.rs
+++ b/src/bindings/fs.rs
@@ -1,0 +1,355 @@
+//! File system binding module.
+//!
+//! This module provides file system operations for reading, writing, and inspecting files.
+//! All operations are gated by the permission system (`--allow-fs`, `--deny-fs`).
+//! Import via `require("@lmb/fs")`.
+//!
+//! # Low-level API (UNIX-style)
+//!
+//! - `open(path, mode)` - Open a file, returns a file handle. Mode: `"r"`, `"w"`, `"a"`.
+//! - `stat(path)` - Get file metadata. Returns `{ size, is_file, is_dir }`.
+//! - `remove(path)` - Remove a file.
+//! - `mkdir(path)` - Create a directory.
+//! - `readdir(path)` - List directory entries. Returns an array of names.
+//!
+//! ## File Handle Methods
+//!
+//! - `read(fmt)` - Read from file. Format: `"*a"` (all), `"*l"` (line), or number (bytes).
+//! - `write(data)` - Write string to file.
+//! - `close()` - Close the file handle.
+//!
+//! # High-level Wrappers
+//!
+//! - `read_file(path)` - Read entire file as string.
+//! - `write_file(path, content)` - Write string to file (overwrite).
+//! - `exists(path)` - Check if path exists.
+//!
+//! # Example
+//!
+//! ```lua
+//! local fs = require("@lmb/fs")
+//!
+//! -- High-level: read and write files
+//! fs:write_file("output.txt", "hello world")
+//! local content = fs:read_file("output.txt")
+//!
+//! -- Low-level: open, read line by line, close
+//! local f = fs:open("output.txt", "r")
+//! local line = f:read("*l")
+//! f:close()
+//!
+//! -- Check existence and metadata
+//! if fs:exists("output.txt") then
+//!     local info = fs:stat("output.txt")
+//!     print(info.size)
+//! end
+//!
+//! -- Directory operations
+//! fs:mkdir("mydir")
+//! local entries = fs:readdir(".")
+//! fs:remove("output.txt")
+//! ```
+
+use std::{
+    io::{BufRead as _, BufReader, Read as _, Write as _},
+    path::PathBuf,
+    sync::Arc,
+};
+
+use mlua::prelude::*;
+use parking_lot::Mutex;
+
+use crate::Permissions;
+
+/// File handle returned by `fs:open()`.
+struct FileHandle {
+    inner: Arc<Mutex<Option<FileHandleInner>>>,
+}
+
+enum FileHandleInner {
+    Reader(BufReader<std::fs::File>),
+    Writer(std::fs::File),
+}
+
+impl FileHandle {
+    fn with_inner<F, T>(inner: &Arc<Mutex<Option<FileHandleInner>>>, f: F) -> LuaResult<T>
+    where
+        F: FnOnce(&mut FileHandleInner) -> LuaResult<T>,
+    {
+        let mut guard = inner.lock();
+        match guard.as_mut() {
+            Some(handle) => f(handle),
+            None => Err(LuaError::runtime("file handle is closed")),
+        }
+    }
+}
+
+impl LuaUserData for FileHandle {
+    fn add_methods<M: LuaUserDataMethods<Self>>(methods: &mut M) {
+        methods.add_method("read", |vm, this, fmt: LuaValue| {
+            FileHandle::with_inner(&this.inner, |handle| {
+                let FileHandleInner::Reader(reader) = handle else {
+                    return Err(LuaError::runtime(
+                        "cannot read from a file opened for writing",
+                    ));
+                };
+
+                if let Some(s) = fmt.as_string().and_then(|s| s.to_str().ok()) {
+                    match &*s {
+                        "*a" | "*all" => {
+                            let mut buf = String::new();
+                            reader.read_to_string(&mut buf).into_lua_err()?;
+                            return vm.to_value(&buf);
+                        }
+                        "*l" | "*line" => {
+                            let mut line = String::new();
+                            if reader.read_line(&mut line).into_lua_err()? == 0 {
+                                return Ok(LuaNil);
+                            }
+                            let trimmed = line.trim_end_matches('\n').trim_end_matches('\r');
+                            return vm.to_value(trimmed);
+                        }
+                        _ => {
+                            return Err(LuaError::runtime(format!("invalid read format: {s}")));
+                        }
+                    }
+                }
+
+                if let Some(n) = fmt.as_usize() {
+                    let mut buf = vec![0u8; n];
+                    let bytes_read = reader.read(&mut buf).into_lua_err()?;
+                    if bytes_read == 0 {
+                        return Ok(LuaNil);
+                    }
+                    buf.truncate(bytes_read);
+                    let s = String::from_utf8(buf).into_lua_err()?;
+                    return vm.to_value(&s);
+                }
+
+                Err(LuaError::runtime(format!("invalid read format: {fmt:?}")))
+            })
+        });
+
+        methods.add_method("write", |_, this, data: String| {
+            FileHandle::with_inner(&this.inner, |handle| {
+                let FileHandleInner::Writer(file) = handle else {
+                    return Err(LuaError::runtime(
+                        "cannot write to a file opened for reading",
+                    ));
+                };
+                let bytes = data.as_bytes();
+                file.write_all(bytes).into_lua_err()?;
+                Ok(bytes.len())
+            })
+        });
+
+        methods.add_method("close", |_, this, ()| {
+            let mut guard = this.inner.lock();
+            *guard = None;
+            Ok(())
+        });
+    }
+}
+
+pub(crate) struct FsBinding {
+    permissions: Option<Permissions>,
+}
+
+impl FsBinding {
+    pub(crate) fn new(permissions: Option<Permissions>) -> Self {
+        Self { permissions }
+    }
+
+    fn check_permission(&self, path: &std::path::Path) -> LuaResult<()> {
+        if let Some(perm) = &self.permissions
+            && !perm.is_path_allowed(path)
+        {
+            return Err(LuaError::runtime(format!(
+                "path is not allowed: {}",
+                path.display()
+            )));
+        }
+        Ok(())
+    }
+}
+
+impl LuaUserData for FsBinding {
+    fn add_methods<M: LuaUserDataMethods<Self>>(methods: &mut M) {
+        // -- Low-level API --
+
+        methods.add_method("open", |_, this, (path, mode): (String, String)| {
+            let path = PathBuf::from(&path);
+            this.check_permission(&path)?;
+
+            let inner = match mode.as_str() {
+                "r" => {
+                    let file = std::fs::File::open(&path).into_lua_err()?;
+                    FileHandleInner::Reader(BufReader::new(file))
+                }
+                "w" => {
+                    let file = std::fs::File::create(&path).into_lua_err()?;
+                    FileHandleInner::Writer(file)
+                }
+                "a" => {
+                    let file = std::fs::OpenOptions::new()
+                        .create(true)
+                        .append(true)
+                        .open(&path)
+                        .into_lua_err()?;
+                    FileHandleInner::Writer(file)
+                }
+                _ => {
+                    return Err(LuaError::runtime(format!(
+                        "invalid file mode: {mode} (expected \"r\", \"w\", or \"a\")"
+                    )));
+                }
+            };
+
+            Ok(FileHandle {
+                inner: Arc::new(Mutex::new(Some(inner))),
+            })
+        });
+
+        methods.add_method("stat", |vm, this, path: String| {
+            let path = PathBuf::from(&path);
+            this.check_permission(&path)?;
+
+            let metadata = std::fs::metadata(&path).into_lua_err()?;
+            let table = vm.create_table()?;
+            table.set("size", metadata.len())?;
+            table.set("is_file", metadata.is_file())?;
+            table.set("is_dir", metadata.is_dir())?;
+            Ok(LuaValue::Table(table))
+        });
+
+        methods.add_method("remove", |_, this, path: String| {
+            let path = PathBuf::from(&path);
+            this.check_permission(&path)?;
+            std::fs::remove_file(&path).into_lua_err()?;
+            Ok(())
+        });
+
+        methods.add_method("mkdir", |_, this, path: String| {
+            let path = PathBuf::from(&path);
+            this.check_permission(&path)?;
+            std::fs::create_dir(&path).into_lua_err()?;
+            Ok(())
+        });
+
+        methods.add_method("readdir", |vm, this, path: String| {
+            let path = PathBuf::from(&path);
+            this.check_permission(&path)?;
+
+            let entries = std::fs::read_dir(&path).into_lua_err()?;
+            let table = vm.create_table()?;
+            let mut idx = 1;
+            for entry in entries {
+                let entry = entry.into_lua_err()?;
+                if let Some(name) = entry.file_name().to_str() {
+                    table.set(idx, name.to_string())?;
+                    idx += 1;
+                }
+            }
+            Ok(LuaValue::Table(table))
+        });
+
+        // -- High-level wrappers --
+
+        methods.add_method("read_file", |_, this, path: String| {
+            let path = PathBuf::from(&path);
+            this.check_permission(&path)?;
+            std::fs::read_to_string(&path).into_lua_err()
+        });
+
+        methods.add_method(
+            "write_file",
+            |_, this, (path, content): (String, String)| {
+                let path = PathBuf::from(&path);
+                this.check_permission(&path)?;
+                std::fs::write(&path, &content).into_lua_err()?;
+                Ok(content.len())
+            },
+        );
+
+        methods.add_method("exists", |_, this, path: String| {
+            let path = PathBuf::from(&path);
+            this.check_permission(&path)?;
+            Ok(path.exists())
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::io::empty;
+
+    use crate::Runner;
+    use crate::permission::{FsPermissions, Permissions};
+
+    fn fs_permissions_for_tmp() -> Permissions {
+        use crate::permission::{EnvPermissions, NetPermissions};
+        use rustc_hash::FxHashSet;
+
+        let canonical = std::path::PathBuf::from("/tmp")
+            .canonicalize()
+            .expect("canonicalize /tmp");
+        Permissions::Some {
+            env: EnvPermissions::All {
+                denied: FxHashSet::default(),
+            },
+            fs: FsPermissions::Some {
+                allowed: [canonical].into_iter().collect(),
+                denied: FxHashSet::default(),
+            },
+            net: NetPermissions::All {
+                denied: FxHashSet::default(),
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn test_fs() {
+        let source = include_str!("../fixtures/bindings/fs.lua");
+        let permissions = fs_permissions_for_tmp();
+        let runner = Runner::builder(source, empty())
+            .permissions(permissions)
+            .build()
+            .expect("build runner");
+        runner
+            .invoke()
+            .call()
+            .await
+            .expect("invoke")
+            .result
+            .expect("result");
+    }
+
+    #[tokio::test]
+    async fn test_fs_permission_denied() {
+        let source = r#"
+            local fs = require("@lmb/fs")
+            return fs:read_file("/etc/passwd")
+        "#;
+        use crate::permission::{EnvPermissions, NetPermissions};
+        use rustc_hash::FxHashSet;
+
+        let permissions = Permissions::Some {
+            env: EnvPermissions::All {
+                denied: FxHashSet::default(),
+            },
+            fs: FsPermissions::Some {
+                allowed: FxHashSet::default(),
+                denied: FxHashSet::default(),
+            },
+            net: NetPermissions::All {
+                denied: FxHashSet::default(),
+            },
+        };
+        let runner = Runner::builder(source, empty())
+            .permissions(permissions)
+            .build()
+            .expect("build runner");
+        let result = runner.invoke().call().await.expect("invoke");
+        assert!(result.result.is_err(), "expected permission denied error");
+    }
+}

--- a/src/bindings/mod.rs
+++ b/src/bindings/mod.rs
@@ -34,6 +34,7 @@ pub(crate) use define_codec_binding;
 
 pub(crate) mod coroutine;
 pub(crate) mod crypto;
+pub(crate) mod fs;
 pub(crate) mod globals;
 pub(crate) mod http;
 pub(crate) mod io;

--- a/src/fixtures/bindings/fs.lua
+++ b/src/fixtures/bindings/fs.lua
@@ -1,0 +1,200 @@
+-- Use temp directory for test files
+local prefix = "/tmp/lmb_test_fs_"
+
+-- Test write_file and read_file
+function test_read_write_file()
+  local fs = require("@lmb/fs")
+  local path = prefix .. "rw.txt"
+  local content = "hello world\n"
+
+  local bytes = fs:write_file(path, content)
+  assert(bytes == #content, "Expected " .. #content .. " bytes written, got " .. tostring(bytes))
+
+  local read = fs:read_file(path)
+  assert(read == content, "Expected '" .. content .. "' but got '" .. tostring(read) .. "'")
+
+  fs:remove(path)
+end
+
+-- Test exists
+function test_exists()
+  local fs = require("@lmb/fs")
+  local path = prefix .. "exists.txt"
+
+  assert(not fs:exists(path), "File should not exist yet")
+
+  fs:write_file(path, "test")
+  assert(fs:exists(path), "File should exist after write")
+
+  fs:remove(path)
+  assert(not fs:exists(path), "File should not exist after remove")
+end
+
+-- Test stat
+function test_stat()
+  local fs = require("@lmb/fs")
+  local path = prefix .. "stat.txt"
+  fs:write_file(path, "12345")
+
+  local info = fs:stat(path)
+  assert(info.size == 5, "Expected size 5, got " .. tostring(info.size))
+  assert(info.is_file == true, "Expected is_file to be true")
+  assert(info.is_dir == false, "Expected is_dir to be false")
+
+  fs:remove(path)
+end
+
+-- Test open/read/close (low-level)
+function test_open_read()
+  local fs = require("@lmb/fs")
+  local path = prefix .. "open_read.txt"
+  fs:write_file(path, "line one\nline two\nline three")
+
+  -- Read all
+  local f = fs:open(path, "r")
+  local all = f:read("*a")
+  assert(all == "line one\nline two\nline three", "read *a failed: " .. tostring(all))
+  f:close()
+
+  -- Read line by line
+  f = fs:open(path, "r")
+  local line1 = f:read("*l")
+  assert(line1 == "line one", "Expected 'line one', got '" .. tostring(line1) .. "'")
+  local line2 = f:read("*l")
+  assert(line2 == "line two", "Expected 'line two', got '" .. tostring(line2) .. "'")
+  local line3 = f:read("*l")
+  assert(line3 == "line three", "Expected 'line three', got '" .. tostring(line3) .. "'")
+  local eof = f:read("*l")
+  assert(eof == nil, "Expected nil at EOF, got " .. tostring(eof))
+  f:close()
+
+  -- Read N bytes
+  f = fs:open(path, "r")
+  local chunk = f:read(4)
+  assert(chunk == "line", "Expected 'line', got '" .. tostring(chunk) .. "'")
+  f:close()
+
+  fs:remove(path)
+end
+
+-- Test open/write/close (low-level)
+function test_open_write()
+  local fs = require("@lmb/fs")
+  local path = prefix .. "open_write.txt"
+
+  local f = fs:open(path, "w")
+  f:write("hello ")
+  f:write("world")
+  f:close()
+
+  local content = fs:read_file(path)
+  assert(content == "hello world", "Expected 'hello world', got '" .. tostring(content) .. "'")
+
+  fs:remove(path)
+end
+
+-- Test append mode
+function test_append()
+  local fs = require("@lmb/fs")
+  local path = prefix .. "append.txt"
+  fs:write_file(path, "first")
+
+  local f = fs:open(path, "a")
+  f:write(" second")
+  f:close()
+
+  local content = fs:read_file(path)
+  assert(content == "first second", "Expected 'first second', got '" .. tostring(content) .. "'")
+
+  fs:remove(path)
+end
+
+-- Test mkdir and readdir
+function test_mkdir_readdir()
+  local fs = require("@lmb/fs")
+  local dir = prefix .. "dir"
+
+  -- Clean up if exists from previous run
+  pcall(function() fs:remove(dir .. "/a.txt") end)
+  pcall(function() fs:remove(dir .. "/b.txt") end)
+
+  pcall(function() fs:mkdir(dir) end)
+
+  fs:write_file(dir .. "/a.txt", "a")
+  fs:write_file(dir .. "/b.txt", "b")
+
+  local entries = fs:readdir(dir)
+  assert(#entries >= 2, "Expected at least 2 entries, got " .. #entries)
+
+  local found_a = false
+  local found_b = false
+  for _, name in ipairs(entries) do
+    if name == "a.txt" then found_a = true end
+    if name == "b.txt" then found_b = true end
+  end
+  assert(found_a, "Expected to find a.txt in directory listing")
+  assert(found_b, "Expected to find b.txt in directory listing")
+
+  fs:remove(dir .. "/a.txt")
+  fs:remove(dir .. "/b.txt")
+end
+
+-- Test error on closed handle
+function test_closed_handle()
+  local fs = require("@lmb/fs")
+  local path = prefix .. "closed.txt"
+  fs:write_file(path, "test")
+
+  local f = fs:open(path, "r")
+  f:close()
+
+  local ok, err = pcall(function() f:read("*a") end)
+  assert(not ok, "Expected error on read after close")
+  assert(string.find(tostring(err), "closed"), "Expected 'closed' in error message")
+
+  fs:remove(path)
+end
+
+-- Test error: read from write handle
+function test_read_from_write_handle()
+  local fs = require("@lmb/fs")
+  local path = prefix .. "read_write_err.txt"
+  local f = fs:open(path, "w")
+
+  local ok, err = pcall(function() f:read("*a") end)
+  assert(not ok, "Expected error on read from write handle")
+  assert(string.find(tostring(err), "writing"), "Expected 'writing' in error message")
+
+  f:close()
+  fs:remove(path)
+end
+
+-- Test error: write to read handle
+function test_write_to_read_handle()
+  local fs = require("@lmb/fs")
+  local path = prefix .. "write_read_err.txt"
+  fs:write_file(path, "test")
+  local f = fs:open(path, "r")
+
+  local ok, err = pcall(function() f:write("data") end)
+  assert(not ok, "Expected error on write to read handle")
+  assert(string.find(tostring(err), "reading"), "Expected 'reading' in error message")
+
+  f:close()
+  fs:remove(path)
+end
+
+function test_fs()
+  test_read_write_file()
+  test_exists()
+  test_stat()
+  test_open_read()
+  test_open_write()
+  test_append()
+  test_mkdir_readdir()
+  test_closed_handle()
+  test_read_from_write_handle()
+  test_write_to_read_handle()
+end
+
+return test_fs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,6 +234,7 @@ impl Runner {
                     .build(),
             )?;
             vm.register_module("@lmb/coroutine", bindings::coroutine::CoroutineBinding {})?;
+            vm.register_module("@lmb/fs", bindings::fs::FsBinding::new(permissions.clone()))?;
             vm.register_module("@lmb/crypto", bindings::crypto::CryptoBinding {})?;
             vm.register_module(
                 "@lmb/http",


### PR DESCRIPTION
## Summary

- Add `@lmb/fs` module with both low-level UNIX-style API (`open`/`read`/`write`/`close`, `stat`, `remove`, `mkdir`, `readdir`) and high-level wrappers (`read_file`, `write_file`, `exists`)
- Extend permission system with `FsPermissions` — path-prefix matching with canonicalization to prevent directory traversal attacks
- Add `--allow-all-fs`, `--allow-fs`, `--deny-fs` CLI flags

## Test plan

- [x] Permission unit tests (7 new test cases)
- [x] Fs module unit tests (10 Lua sub-tests + permission denied test)
- [x] Guided tour integration test (3 new executable examples)
- [x] All existing tests pass
- [x] `cargo fmt --check` and `cargo clippy` clean

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)