### PR TITLE
feat: add @lmb/fs module for filesystem I/O

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.24.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
  "gimli",
 ]
@@ -34,16 +34,16 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "once_cell",
  "version_check",
 ]
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
@@ -104,29 +104,29 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.3"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.9"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arrayvec"
@@ -191,9 +191,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59446ce19cd142f8833f856eb31f3eb097812d1479ab224f54d72428ca21ea22"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
@@ -239,9 +239,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.75"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -249,7 +249,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -299,9 +299,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "bitvec"
@@ -355,14 +355,14 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "borsh"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad8646f98db542e39fc66e68a20b2144f6a732636df7c2354e74645faaa433ce"
+checksum = "d1da5ab77c1437701eeff7c88d968729e7766172279eab0676857b3d63af7a6f"
 dependencies = [
  "borsh-derive",
  "cfg_aliases",
@@ -370,22 +370,22 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd1d3c0c2f5833f22386f252fe8ed005c7f59fdcddeef025c01b4c3b9fd9ac3"
+checksum = "0686c856aa6aac0c4498f936d7d6a02df690f614c03e4d906d1018062b5c5e2c"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "bstr"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
 dependencies = [
  "memchr",
  "serde",
@@ -393,9 +393,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "byte-unit"
@@ -438,12 +438,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,10 +466,11 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.30"
+version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
@@ -483,9 +478,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
@@ -503,7 +498,7 @@ dependencies = [
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-link 0.2.0",
+ "windows-link",
 ]
 
 [[package]]
@@ -545,9 +540,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.58"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63be97961acde393029492ce0be7a1af7e323e6bae9511ebfac33751be5e6806"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -555,9 +550,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.58"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f13174bda5dfd69d7e947827e5af4b0f2f94a4a3ee92912fba07a66150f21e2"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
 dependencies = [
  "anstream",
  "anstyle",
@@ -574,7 +569,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -606,11 +601,11 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "colored"
-version = "3.0.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -734,7 +729,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strict",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -855,9 +850,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a79c4acb1fd5fa3d9304be4c76e031c54d2e92d172a393e24b19a14fe8532fe9"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -865,27 +860,26 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.21.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74875de90daf30eb59609910b84d4d368103aaec4c924824c6799b28f77d6a1d"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.21.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79f8e61677d5df9167cd85265f8e5f64b215cdea3fb55eebc3e622e44c7a146"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -908,9 +902,9 @@ checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
 dependencies = [
  "powerfmt",
 ]
@@ -941,7 +935,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "unicode-xid",
 ]
 
@@ -955,7 +949,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -992,7 +986,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1057,22 +1051,23 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "erased-serde"
-version = "0.4.6"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7"
+checksum = "89e8918065695684b2b0702da20382d5ae6065cf3327bc2d6436bd49a71ce9f3"
 dependencies = [
  "serde",
+ "serde_core",
  "typeid",
 ]
 
 [[package]]
 name = "errno"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1101,7 +1096,7 @@ checksum = "f464e1e518bc97a6749590758411784df7dda4f36384e1fb11a58f040c1d0459"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1132,6 +1127,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
@@ -1199,9 +1200,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1214,9 +1215,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1224,15 +1225,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1241,38 +1242,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1282,7 +1283,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -1298,51 +1298,64 @@ dependencies = [
 
 [[package]]
 name = "getopts"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cba6ae63eb948698e300f645f87c70f76630d505f23b8907cf1e193ee85048c1"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
 dependencies = [
- "unicode-width 0.2.1",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
  "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "wasip2",
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "gimli"
-version = "0.31.1"
+name = "getrandom"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "h2"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1350,7 +1363,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.11.4",
+ "indexmap 2.13.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1359,12 +1372,13 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.6.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1378,12 +1392,18 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "foldhash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "hashlink"
@@ -1391,7 +1411,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -1523,7 +1543,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.0",
+ "socket2",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -1533,9 +1553,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.63"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1557,9 +1577,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -1570,9 +1590,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1583,11 +1603,10 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
@@ -1598,48 +1617,50 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "2.0.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "potential_utf",
  "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "2.0.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
 
 [[package]]
 name = "icu_provider"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
- "stable_deref_trait",
- "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -1680,12 +1701,14 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.11.4"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.4",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1700,9 +1723,9 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.3.20"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab08d7cd2c5897f2c949e5383ea7c7db03fb19130ffcfbf7eda795137ae3cb83"
+checksum = "009ae045c87e7082cb72dab0ccd01ae075dd00141ddc108f43a0ea150a9e7227"
 dependencies = [
  "rustversion",
 ]
@@ -1715,9 +1738,9 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "iri-string"
-version = "0.7.8"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
 dependencies = [
  "memchr",
  "serde",
@@ -1725,13 +1748,13 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1742,9 +1765,9 @@ checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
@@ -1757,9 +1780,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jiff"
@@ -1782,24 +1805,24 @@ checksum = "f7946b4325269738f270bb55b3c19ab5c5040525f83fd625259422a9d25d9be5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "jobserver"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1825,7 +1848,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1835,10 +1858,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "libc"
-version = "0.2.177"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.182"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -1859,15 +1888,15 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "litrs"
@@ -1924,6 +1953,7 @@ dependencies = [
  "snapbox",
  "string-offsets",
  "syntect",
+ "tempfile",
  "termimad",
  "test-case",
  "thiserror",
@@ -1945,9 +1975,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru-slab"
@@ -1966,9 +1996,9 @@ dependencies = [
 
 [[package]]
 name = "luajit-src"
-version = "210.6.1+f9140a6"
+version = "210.6.6+707c12b"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "813bd31f2759443affa687c0d9c5eb5cf6cb0e898810ab197408431d746054bf"
+checksum = "a86cc925d4053d0526ae7f5bc765dbd0d7a5d1a63d43974f4966cb349ca63295"
 dependencies = [
  "cc",
  "which",
@@ -1976,9 +2006,9 @@ dependencies = [
 
 [[package]]
 name = "luau0-src"
-version = "0.18.1+luau706"
+version = "0.18.2+luau708"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1faa5fea4290893267786058fd724e54f93a3efebd9ee17681d83c9a4f325841"
+checksum = "eed3214ab526e7e7b76c3f324a965d363db94a99ae67f65e67ec6fc499eb5e6d"
 dependencies = [
  "cc",
 ]
@@ -2016,9 +2046,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memo-map"
@@ -2052,9 +2082,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minijinja"
-version = "2.12.0"
+version = "2.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9f264d75233323f4b7d2f03aefe8a990690cdebfbfe26ea86bcbaec5e9ac990"
+checksum = "b479616bb6f0779fb0f3964246beda02d4b01144e1b0d5519616e012ccc2a245"
 dependencies = [
  "memo-map",
  "self_cell",
@@ -2089,14 +2119,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.1+wasi-snapshot-preview1",
- "windows-sys 0.61.1",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2183,11 +2213,11 @@ checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.50.1"
+version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2281,9 +2311,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.7"
+version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
 ]
@@ -2296,9 +2326,9 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "once_cell_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oorandom"
@@ -2317,19 +2347,19 @@ dependencies = [
 
 [[package]]
 name = "os_pipe"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db335f4760b14ead6290116f2427bf33a14d4f0617d49f78a246de10c1831224"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "owo-colors"
-version = "4.2.2"
+version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48dd4f4a2c8405440fd0462561f0e5806bd0f77e86f51c761481bdd4018b545e"
+checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
 
 [[package]]
 name = "page_size"
@@ -2361,7 +2391,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link 0.2.0",
+ "windows-link",
 ]
 
 [[package]]
@@ -2378,20 +2408,19 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.1"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
 dependencies = [
  "memchr",
- "thiserror",
  "ucd-trie",
 ]
 
 [[package]]
 name = "pest_derive"
-version = "2.8.1"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb056d9e8ea77922845ec74a1c4e8fb17e7c218cc4fc11a15c5d25e189aa40bc"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2399,22 +2428,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.1"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87e404e638f781eb3202dc82db6760c8ae8a1eeef7fb3fa8264b2ef280504966"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.8.1"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
  "sha2",
@@ -2445,7 +2474,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64",
- "indexmap 2.11.4",
+ "indexmap 2.13.0",
  "quick-xml",
  "serde",
  "time",
@@ -2481,24 +2510,24 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
 dependencies = [
  "portable-atomic",
 ]
 
 [[package]]
 name = "potential_utf"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
@@ -2530,19 +2559,19 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.36"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff24dfcda44452b9816fff4cd4227e1bb73ff5a2f1bc1105aa92fb8565ce44d2"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
  "toml_edit",
 ]
@@ -2606,9 +2635,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626214629cda6781b6dc1d316ba307189c85ba657213ce642d9c77670f8202c8"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -2617,7 +2646,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2",
  "thiserror",
  "tokio",
  "tracing",
@@ -2626,12 +2655,12 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.12"
+version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
  "bytes",
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "lru-slab",
  "rand 0.9.2",
  "ring",
@@ -2647,16 +2676,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.13"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcebb1209ee276352ef14ff8732e24cc2b02bbac986cd74a4c81bcb2f9881970"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2698,7 +2727,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2718,7 +2747,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2727,23 +2756,23 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
 name = "rayon"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
 dependencies = [
  "either",
  "rayon-core",
@@ -2751,9 +2780,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -2761,9 +2790,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.15"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8af0dde094006011e6a740d4879319439489813bd0bcdc7d821beaeeff48ec"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
 ]
@@ -2785,14 +2814,14 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2802,9 +2831,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2813,9 +2842,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "rend"
@@ -2884,7 +2913,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -2892,9 +2921,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.7.45"
+version = "0.7.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9008cd6385b9e161d8229e1f6549dd23c3d022f132a2ea37ac3a10ac4935779b"
+checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
 dependencies = [
  "bitvec",
  "bytecheck",
@@ -2910,9 +2939,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.7.45"
+version = "0.7.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503d1d27590a2b0a3a4ca4c94755aa2875657196ecbf401a42eff41d7de532c0"
+checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2921,13 +2950,11 @@ dependencies = [
 
 [[package]]
 name = "rmp"
-version = "0.8.14"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "228ed7c16fa39782c3b3468e974aec2795e9089153cd08ee2e9aefb3613334c4"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
 dependencies = [
- "byteorder",
  "num-traits",
- "paste",
 ]
 
 [[package]]
@@ -2971,9 +2998,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.37.2"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b203a6425500a03e0919c42d3c47caca51e79f1132046626d2c8871c5092035d"
+checksum = "61f703d19852dbf87cbc513643fa81428361eb6940f1ac14fd58155d295a3eb0"
 dependencies = [
  "arrayvec",
  "borsh",
@@ -2987,9 +3014,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.25"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
@@ -3008,22 +3035,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.8"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.29"
+version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
+checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
  "once_cell",
  "ring",
@@ -3035,9 +3062,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.12.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3045,9 +3072,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.4"
+version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3056,15 +3083,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -3077,9 +3104,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9558e172d4e8533736ba97870c4b2cd63f84b382a3d6eb063da41b91cce17289"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -3101,9 +3128,9 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "self_cell"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f7d95a54511e0c7be3f51e8867aa8cf35148d7b9445d44de2f943e2b206e749"
+checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
 
 [[package]]
 name = "semver"
@@ -3148,7 +3175,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3211,17 +3238,18 @@ checksum = "aafbefbe175fa9bf03ca83ef89beecff7d2a95aaacd5732325b90ac8c3bd7b90"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "serde_path_to_error"
-version = "0.1.17"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
 dependencies = [
  "itoa",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3251,7 +3279,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.11.4",
+ "indexmap 2.13.0",
  "itoa",
  "ryu",
  "serde",
@@ -3346,9 +3374,9 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -3384,7 +3412,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3415,29 +3443,19 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
-dependencies = [
- "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strict"
@@ -3474,9 +3492,9 @@ dependencies = [
 
 [[package]]
 name = "supports-hyperlinks"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f44ed3c63152de6a9f90acbea1a110441de43006ea51bcce8f436196a288b"
+checksum = "e396b6523b11ccb83120b115a0b7366de372751aa6edf19844dfb13a6af97e91"
 
 [[package]]
 name = "supports-unicode"
@@ -3497,9 +3515,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3523,7 +3541,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3576,15 +3594,15 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.20.0"
+version = "3.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
- "getrandom 0.3.3",
+ "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3605,12 +3623,12 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
+checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
 dependencies = [
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3631,7 +3649,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3642,7 +3660,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "test-case-core",
 ]
 
@@ -3653,7 +3671,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 dependencies = [
  "unicode-linebreak",
- "unicode-width 0.2.1",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -3673,7 +3691,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3718,9 +3736,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3738,9 +3756,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3762,9 +3780,9 @@ dependencies = [
  "mio",
  "parking_lot",
  "pin-project-lite",
- "socket2 0.6.0",
+ "socket2",
  "tokio-macros",
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3775,14 +3793,14 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.2"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
@@ -3790,9 +3808,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.15"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3803,11 +3821,11 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.0.1+spec-1.1.0"
+version = "1.0.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe30f93627849fa362d4a602212d41bb237dc2bd0f8ba0b2ce785012e124220"
+checksum = "c7614eaf19ad818347db24addfa201729cf2a9b6fdfd9eb0ab870fcacc606c0c"
 dependencies = [
- "indexmap 2.11.4",
+ "indexmap 2.13.0",
  "serde_core",
  "serde_spanned",
  "toml_datetime 1.0.0+spec-1.1.0",
@@ -3818,9 +3836,12 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.11"
+version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "toml_datetime"
@@ -3833,12 +3854,13 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.27"
+version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
- "indexmap 2.11.4",
- "toml_datetime 0.6.11",
+ "indexmap 2.13.0",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
  "winnow",
 ]
 
@@ -3923,7 +3945,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3979,9 +4001,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "typetag"
@@ -4004,7 +4026,7 @@ checksum = "27a7a9b72ba121f6f1f6c3632b85604cac41aedb5ddc70accbebb6cac83de846"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4015,15 +4037,15 @@ checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicase"
-version = "2.8.1"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-linebreak"
@@ -4045,9 +4067,9 @@ checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
@@ -4081,9 +4103,9 @@ dependencies = [
 
 [[package]]
 name = "utf8-width"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86bd8d4e895da8537e5315b8254664e6b769c4ff3db18321b297a1e7004392e3"
+checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
 
 [[package]]
 name = "utf8_iter"
@@ -4099,9 +4121,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.20.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
+checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4166,47 +4188,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasi"
-version = "0.14.2+wasi-0.2.4"
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
- "wit-bindgen-rt",
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
 dependencies = [
  "cfg-if",
+ "futures-util",
  "js-sys",
  "once_cell",
  "wasm-bindgen",
@@ -4215,9 +4234,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4225,31 +4244,65 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
- "wasm-bindgen-backend",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.77"
+name = "wasm-encoder"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.13.0",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.0",
+ "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4267,20 +4320,19 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.2"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "which"
-version = "7.0.3"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
+checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
 dependencies = [
- "either",
  "env_home",
  "rustix",
  "winsafe",
@@ -4304,11 +4356,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4319,86 +4371,72 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
-version = "0.56.0"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-result 0.1.2",
- "windows-targets 0.52.6",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
 name = "windows-implement"
-version = "0.56.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "windows-interface"
-version = "0.56.0"
+version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-registry"
-version = "0.5.3"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link",
+ "windows-result",
  "windows-strings",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.1.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -4427,29 +4465,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.4",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
 name = "windows-sys"
-version = "0.61.1"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.0",
+ "windows-link",
 ]
 
 [[package]]
@@ -4470,11 +4499,11 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.4"
+version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d42b7b7f66d2a06854650af09cfdf8713e427a439c97ad65a6375318033ac4b"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.2.0",
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -4625,9 +4654,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
@@ -4639,19 +4668,98 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
+name = "wit-bindgen"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.13.0",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
  "bitflags",
+ "indexmap 2.13.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.13.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
 ]
 
 [[package]]
 name = "writeable"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "wyz"
@@ -4679,11 +4787,10 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
 dependencies = [
- "serde",
  "stable_deref_trait",
  "yoke-derive",
  "zerofrom",
@@ -4691,34 +4798,34 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.26"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.26"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4738,21 +4845,21 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -4761,9 +4868,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.2"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -4772,17 +4879,17 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.12"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fc5a66a20078bf1251bde995aa2fdcc4b800c70b5d92dd2c62abc5c60f679f8"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ curl-parser = "0.6.0"
 full_moon = "2.0.0"
 mockito = "1.7.2"
 snapbox = { version = "1.0.0", features = ["cmd"] }
+tempfile = "3"
 test-case = "3.3.1"
 
 [profile.dev]

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For more information, please read [the guided tour](docs/guided-tour.md).
 
 ## Features
 
-- Batteries included: Comes with handy libraries such as `crypto`, `http`, and `json`.
+- Batteries included: Comes with handy libraries such as `crypto`, `fs`, `http`, and `json`.
 - Easy to use: Run Lua scripts and functions from the command line.
 - Fast: Optimized for quick execution, making it suitable for low-end hardware.
 - Secure: Runs Lua code in a sandboxed environment provided by Luau to prevent unwanted side effects.

--- a/docs/guided-tour.md
+++ b/docs/guided-tour.md
@@ -236,6 +236,111 @@ end
 return getenv
 ```
 
+## Filesystem
+
+The `@lmb/fs` module provides Lua-native file I/O operations. All operations require explicit permission flags (`--allow-read`, `--allow-write`) to access the filesystem.
+
+### Reading and writing files
+
+```text
+local fs = require("@lmb/fs")
+
+-- Write to a file
+local f = fs:open("/tmp/hello.txt", "w")
+f:write("hello world\n")
+f:close()
+
+-- Read from a file
+local f = fs:open("/tmp/hello.txt", "r")
+local content = f:read("*a")  -- read all
+f:close()
+
+-- Read line by line
+local f = fs:open("/tmp/hello.txt", "r")
+local line = f:read("*l")     -- read one line
+f:close()
+
+-- Read N bytes
+local f = fs:open("/tmp/hello.txt", "r")
+local bytes = f:read(5)       -- read 5 bytes
+f:close()
+```
+
+### File modes
+
+| Mode | Description |
+|------|-------------|
+| `"r"` | Read only (default) |
+| `"w"` | Write only (creates/truncates) |
+| `"a"` | Append only (creates if needed) |
+| `"r+"` | Read and write |
+| `"w+"` | Read and write (creates/truncates) |
+| `"a+"` | Read and append (creates if needed) |
+
+### Iterating lines
+
+```text
+local fs = require("@lmb/fs")
+
+-- Module-level shorthand
+for line in fs:lines("/tmp/data.txt") do
+    print(line)
+end
+
+-- Handle-level iterator
+local f = fs:open("/tmp/data.txt", "r")
+for line in f:lines() do
+    print(line)
+end
+f:close()
+```
+
+### File operations
+
+```text
+local fs = require("@lmb/fs")
+
+-- Check if a path exists
+if fs:exists("/tmp/data.txt") then
+    print("file exists")
+end
+
+-- List directory contents
+local entries = fs:list("/tmp")
+for _, name in ipairs(entries) do
+    print(name)
+end
+
+-- Remove a file
+fs:remove("/tmp/old.txt")
+
+-- Rename a file
+fs:rename("/tmp/old.txt", "/tmp/new.txt")
+
+-- Check file handle type
+local f = fs:open("/tmp/data.txt", "r")
+print(fs.type(f))     -- "file"
+f:close()
+print(fs.type(f))     -- "closed file"
+print(fs.type("str")) -- nil
+```
+
+### Permission flags
+
+```bash
+# Allow reading from a directory
+$ lmb --allow-read /data eval --file script.lua
+
+# Allow reading and writing to specific paths
+$ lmb --allow-read /data --allow-write /tmp eval --file script.lua
+
+# Allow all filesystem access
+$ lmb --allow-all-read --allow-all-write eval --file script.lua
+
+# Deny specific paths while allowing all others
+$ lmb --allow-all-read --deny-read /etc/shadow eval --file script.lua
+```
+
 ## Modules
 
 ### Coroutines

--- a/docs/guided-tour.md
+++ b/docs/guided-tour.md
@@ -270,14 +270,14 @@ return write_and_read
 
 ### Supported file modes
 
-| Mode | Description |
-|------|-------------|
-| `"r"` | Read only (default) |
-| `"w"` | Write only (creates/truncates) |
-| `"a"` | Append only (creates if needed) |
-| `"r+"` | Read and write |
-| `"w+"` | Read and write (creates/truncates) |
-| `"a+"` | Read and append (creates if needed) |
+| Mode | Read | Write | Creates | Truncates | File must exist |
+|------|:----:|:-----:|:-------:|:---------:|:---------------:|
+| `"r"` | O | | | | O |
+| `"w"` | | O | O | O | |
+| `"a"` | | O (append) | O | | |
+| `"r+"` | O | O | | | O |
+| `"w+"` | O | O | O | O | |
+| `"a+"` | O | O (append) | O | | |
 
 ### Iterating lines
 

--- a/docs/guided-tour.md
+++ b/docs/guided-tour.md
@@ -15,7 +15,7 @@ Lmb currently uses Luau from Roblox.
 --name = "Luau Version"
 --]]
 function luau_version()
-  local version = "0.706"
+  local version = "0.708"
   assert(_G._VERSION == "Luau " .. version, "Expected Luau version " .. version .. ", but got " .. _G._VERSION)
 end
 

--- a/src/bindings/fs.rs
+++ b/src/bindings/fs.rs
@@ -1,0 +1,949 @@
+//! Filesystem binding module.
+//!
+//! This module provides filesystem I/O operations for reading and writing files.
+//! Import via `require("@lmb/fs")`.
+//!
+//! All operations require explicit permissions via `--allow-read` and `--allow-write`
+//! CLI flags. Without permissions, all filesystem operations are denied.
+//!
+//! # Available Methods
+//!
+//! - `open(path, mode)` - Open a file and return a file handle. Returns `(handle, nil)` on
+//!   success or `(nil, error)` on failure.
+//! - `lines(path)` - Open a file and return a line iterator.
+//! - `type(obj)` - Check if a value is a file handle. Returns `"file"`, `"closed file"`, or `nil`.
+//! - `remove(path)` - Remove a file.
+//! - `rename(old, new)` - Rename a file.
+//! - `exists(path)` - Check if a path exists.
+//! - `list(path)` - List directory contents, returning a table of filenames.
+//!
+//! # File Handle Methods
+//!
+//! - `read(fmt)` - Read from file. Supports `"*a"` (all), `"*l"` (line), `"*n"` (number),
+//!   and `N` (N bytes).
+//! - `write(...)` - Write strings to file.
+//! - `lines()` - Return a line iterator.
+//! - `seek(whence, offset)` - Seek to position. `whence` is `"set"`, `"cur"`, or `"end"`.
+//! - `flush()` - Flush buffered writes.
+//! - `close()` - Close the file handle.
+//!
+//! # Modes
+//!
+//! - `"r"` - Read only (default)
+//! - `"w"` - Write only (creates/truncates)
+//! - `"a"` - Append only (creates if needed)
+//! - `"r+"` - Read and write
+//! - `"w+"` - Read and write (creates/truncates)
+//! - `"a+"` - Read and append (creates if needed)
+//!
+//! # Example
+//!
+//! ```lua
+//! local fs = require("@lmb/fs")
+//!
+//! -- Write to a file
+//! local f = fs.open("/tmp/hello.txt", "w")
+//! f:write("hello world\n")
+//! f:close()
+//!
+//! -- Read from a file
+//! local f = fs.open("/tmp/hello.txt", "r")
+//! local content = f:read("*a")
+//! f:close()
+//!
+//! -- Iterate over lines
+//! for line in fs.lines("/tmp/hello.txt") do
+//!     print(line)
+//! end
+//!
+//! -- Check existence and list directory
+//! if fs.exists("/tmp") then
+//!     local entries = fs.list("/tmp")
+//!     for _, name in ipairs(entries) do
+//!         print(name)
+//!     end
+//! end
+//! ```
+
+use std::{
+    fmt,
+    fs::{File, OpenOptions},
+    io::{BufRead, BufReader, Read, Seek, SeekFrom, Write},
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use bon::bon;
+use mlua::prelude::*;
+use parking_lot::Mutex;
+
+use crate::Permissions;
+
+/// A file handle wrapping a buffered reader/writer.
+///
+/// The inner `Option` tracks closed state: `None` means the handle has been closed.
+pub(crate) struct FileHandleBinding {
+    inner: Arc<Mutex<Option<BufReader<File>>>>,
+    path: String,
+}
+
+impl fmt::Debug for FileHandleBinding {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let state = if self.inner.lock().is_some() {
+            "open"
+        } else {
+            "closed"
+        };
+        f.debug_struct("FileHandleBinding")
+            .field("path", &self.path)
+            .field("state", &state)
+            .finish()
+    }
+}
+
+impl LuaUserData for FileHandleBinding {
+    fn add_methods<M: LuaUserDataMethods<Self>>(methods: &mut M) {
+        methods.add_method("read", |vm, this, fmt: LuaValue| {
+            let mut guard = this.inner.lock();
+            let reader = guard
+                .as_mut()
+                .ok_or_else(|| LuaError::runtime("attempt to use a closed file"))?;
+
+            if let Some(f) = fmt.as_string().and_then(|s| s.to_str().ok()) {
+                match &*f {
+                    "*a" | "*all" => {
+                        let mut buf = String::new();
+                        reader.read_to_string(&mut buf).into_lua_err()?;
+                        return vm.create_string(&buf).map(LuaValue::String);
+                    }
+                    "*l" | "*line" => {
+                        let mut line = String::new();
+                        let n = reader.read_line(&mut line).into_lua_err()?;
+                        if n == 0 {
+                            return Ok(LuaNil);
+                        }
+                        let trimmed = line.trim_end_matches('\n').trim_end_matches('\r');
+                        return vm.create_string(trimmed).map(LuaValue::String);
+                    }
+                    "*n" | "*number" => {
+                        let mut line = String::new();
+                        let n = reader.read_line(&mut line).into_lua_err()?;
+                        if n == 0 {
+                            return Ok(LuaNil);
+                        }
+                        return match line.trim().parse::<f64>() {
+                            Ok(num) => Ok(LuaValue::Number(num)),
+                            Err(_) => Ok(LuaNil),
+                        };
+                    }
+                    _ => {
+                        return Err(LuaError::runtime(format!("invalid format '{f}'")));
+                    }
+                }
+            }
+
+            if let Some(n) = fmt.as_usize() {
+                let mut buf = vec![0u8; n];
+                let read = reader.read(&mut buf).into_lua_err()?;
+                if read == 0 {
+                    return Ok(LuaNil);
+                }
+                buf.truncate(read);
+                return vm.create_string(&buf).map(LuaValue::String);
+            }
+
+            Err(LuaError::runtime(format!("invalid option {fmt:?}")))
+        });
+
+        methods.add_method("write", |_, this, values: LuaMultiValue| {
+            let mut guard = this.inner.lock();
+            let reader = guard
+                .as_mut()
+                .ok_or_else(|| LuaError::runtime("attempt to use a closed file"))?;
+            let file = reader.get_mut();
+            for value in &values {
+                match value {
+                    LuaValue::String(s) => {
+                        file.write_all(&s.as_bytes()).into_lua_err()?;
+                    }
+                    LuaValue::Integer(n) => {
+                        write!(file, "{n}").into_lua_err()?;
+                    }
+                    LuaValue::Number(n) => {
+                        write!(file, "{n}").into_lua_err()?;
+                    }
+                    _ => {
+                        return Err(LuaError::runtime(format!(
+                            "invalid value for write: {value:?}"
+                        )));
+                    }
+                }
+            }
+            Ok(())
+        });
+
+        methods.add_method("lines", |vm, this, ()| {
+            let inner = this.inner.clone();
+            let f = vm.create_function(move |vm, ()| {
+                let mut guard = inner.lock();
+                let reader = guard
+                    .as_mut()
+                    .ok_or_else(|| LuaError::runtime("attempt to use a closed file"))?;
+                let mut line = String::new();
+                let n = reader.read_line(&mut line).into_lua_err()?;
+                if n == 0 {
+                    return Ok(LuaNil);
+                }
+                let trimmed = line.trim_end_matches('\n').trim_end_matches('\r');
+                vm.create_string(trimmed).map(LuaValue::String)
+            })?;
+            Ok(f)
+        });
+
+        methods.add_method(
+            "seek",
+            |_, this, (whence, offset): (Option<String>, Option<i64>)| {
+                let mut guard = this.inner.lock();
+                let reader = guard
+                    .as_mut()
+                    .ok_or_else(|| LuaError::runtime("attempt to use a closed file"))?;
+                let whence_str = whence.as_deref().unwrap_or("cur");
+                let offset = offset.unwrap_or(0);
+                let pos = match whence_str {
+                    "set" => SeekFrom::Start(u64::try_from(offset).into_lua_err()?),
+                    "cur" => SeekFrom::Current(offset),
+                    "end" => SeekFrom::End(offset),
+                    _ => return Err(LuaError::runtime(format!("invalid whence '{whence_str}'"))),
+                };
+                let new_pos = reader.seek(pos).into_lua_err()?;
+                Ok(new_pos)
+            },
+        );
+
+        methods.add_method("flush", |_, this, ()| {
+            let mut guard = this.inner.lock();
+            let reader = guard
+                .as_mut()
+                .ok_or_else(|| LuaError::runtime("attempt to use a closed file"))?;
+            reader.get_mut().flush().into_lua_err()?;
+            Ok(())
+        });
+
+        methods.add_method("close", |_, this, ()| {
+            let mut guard = this.inner.lock();
+            if guard.is_none() {
+                return Err(LuaError::runtime("attempt to use a closed file"));
+            }
+            *guard = None;
+            Ok(())
+        });
+    }
+}
+
+/// Filesystem binding providing file I/O operations.
+pub(crate) struct FsBinding {
+    permissions: Option<Permissions>,
+}
+
+impl fmt::Debug for FsBinding {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FsBinding")
+            .field("permissions", &self.permissions)
+            .finish()
+    }
+}
+
+#[bon]
+impl FsBinding {
+    #[builder]
+    pub(crate) fn new(permissions: Option<Permissions>) -> Self {
+        Self { permissions }
+    }
+
+    /// Canonicalize a path for permission checking.
+    /// For existing paths, uses `std::fs::canonicalize`.
+    /// For non-existing paths, canonicalizes the parent directory and appends the file name.
+    fn canonicalize_for_check(path: &Path) -> std::io::Result<PathBuf> {
+        if path.exists() {
+            std::fs::canonicalize(path)
+        } else if let Some(parent) = path.parent() {
+            let canonical_parent = if parent.as_os_str().is_empty() {
+                std::fs::canonicalize(".")?
+            } else {
+                std::fs::canonicalize(parent)?
+            };
+            if let Some(file_name) = path.file_name() {
+                Ok(canonical_parent.join(file_name))
+            } else {
+                Ok(canonical_parent)
+            }
+        } else {
+            std::fs::canonicalize(path)
+        }
+    }
+
+    /// Check read permission for a path.
+    /// Returns the canonicalized path on success.
+    fn check_read_permission(&self, path: &str) -> Result<PathBuf, String> {
+        let canonical =
+            Self::canonicalize_for_check(Path::new(path)).map_err(|e| format!("{path}: {e}"))?;
+        match &self.permissions {
+            None => Err(format!(
+                "{path}: permission denied (no permissions granted)"
+            )),
+            Some(perm) => {
+                if perm.is_read_allowed(&canonical) {
+                    Ok(canonical)
+                } else {
+                    Err(format!("{path}: read permission denied"))
+                }
+            }
+        }
+    }
+
+    /// Check write permission for a path.
+    /// Returns the canonicalized path on success.
+    fn check_write_permission(&self, path: &str) -> Result<PathBuf, String> {
+        let canonical =
+            Self::canonicalize_for_check(Path::new(path)).map_err(|e| format!("{path}: {e}"))?;
+        match &self.permissions {
+            None => Err(format!(
+                "{path}: permission denied (no permissions granted)"
+            )),
+            Some(perm) => {
+                if perm.is_write_allowed(&canonical) {
+                    Ok(canonical)
+                } else {
+                    Err(format!("{path}: write permission denied"))
+                }
+            }
+        }
+    }
+}
+
+/// Determine if a mode string requires read permission
+fn mode_needs_read(mode: &str) -> bool {
+    matches!(mode, "r" | "r+" | "w+" | "a+")
+}
+
+/// Determine if a mode string requires write permission
+fn mode_needs_write(mode: &str) -> bool {
+    matches!(mode, "w" | "a" | "r+" | "w+" | "a+")
+}
+
+impl LuaUserData for FsBinding {
+    fn add_methods<M: LuaUserDataMethods<Self>>(methods: &mut M) {
+        methods.add_method(
+            "open",
+            |vm, this, (path, mode): (String, Option<String>)| {
+                let mode = mode.as_deref().unwrap_or("r");
+
+                // Check permissions based on mode
+                if mode_needs_read(mode)
+                    && let Err(e) = this.check_read_permission(&path)
+                {
+                    return Ok((LuaNil, LuaValue::String(vm.create_string(&e)?)));
+                }
+                if mode_needs_write(mode)
+                    && let Err(e) = this.check_write_permission(&path)
+                {
+                    return Ok((LuaNil, LuaValue::String(vm.create_string(&e)?)));
+                }
+
+                let file = match mode {
+                    "r" => File::open(&path),
+                    "w" => File::create(&path),
+                    "a" => OpenOptions::new().append(true).create(true).open(&path),
+                    "r+" => OpenOptions::new().read(true).write(true).open(&path),
+                    "w+" => OpenOptions::new()
+                        .read(true)
+                        .write(true)
+                        .create(true)
+                        .truncate(true)
+                        .open(&path),
+                    "a+" => OpenOptions::new()
+                        .read(true)
+                        .append(true)
+                        .create(true)
+                        .open(&path),
+                    _ => {
+                        let msg = format!("invalid mode '{mode}'");
+                        return Ok((LuaNil, LuaValue::String(vm.create_string(&msg)?)));
+                    }
+                };
+
+                match file {
+                    Ok(f) => {
+                        let handle = FileHandleBinding {
+                            inner: Arc::new(Mutex::new(Some(BufReader::new(f)))),
+                            path: path.clone(),
+                        };
+                        Ok((LuaValue::UserData(vm.create_userdata(handle)?), LuaNil))
+                    }
+                    Err(e) => {
+                        let msg = format!("{path}: {e}");
+                        Ok((LuaNil, LuaValue::String(vm.create_string(&msg)?)))
+                    }
+                }
+            },
+        );
+
+        methods.add_method("lines", |vm, this, path: String| {
+            let canonical = this
+                .check_read_permission(&path)
+                .map_err(LuaError::runtime)?;
+            let file = File::open(&canonical).into_lua_err()?;
+            let inner = Arc::new(Mutex::new(Some(BufReader::new(file))));
+            let f = vm.create_function(move |vm, ()| {
+                let mut guard = inner.lock();
+                let reader = match guard.as_mut() {
+                    Some(r) => r,
+                    None => return Ok(LuaNil),
+                };
+                let mut line = String::new();
+                let n = reader.read_line(&mut line).into_lua_err()?;
+                if n == 0 {
+                    // Close the file when we reach EOF
+                    *guard = None;
+                    return Ok(LuaNil);
+                }
+                let trimmed = line.trim_end_matches('\n').trim_end_matches('\r');
+                vm.create_string(trimmed).map(LuaValue::String)
+            })?;
+            Ok(f)
+        });
+
+        methods.add_function("type", |_, obj: LuaValue| match obj {
+            LuaValue::UserData(ud) => {
+                if ud.is::<FileHandleBinding>() {
+                    let handle = ud.borrow::<FileHandleBinding>().into_lua_err()?;
+                    let guard = handle.inner.lock();
+                    if guard.is_some() {
+                        Ok(Some("file".to_string()))
+                    } else {
+                        Ok(Some("closed file".to_string()))
+                    }
+                } else {
+                    Ok(None)
+                }
+            }
+            _ => Ok(None),
+        });
+
+        methods.add_method("remove", |_, this, path: String| {
+            this.check_write_permission(&path)
+                .map_err(LuaError::runtime)?;
+            std::fs::remove_file(&path).into_lua_err()?;
+            Ok(())
+        });
+
+        methods.add_method("rename", |_, this, (old, new): (String, String)| {
+            this.check_write_permission(&old)
+                .map_err(LuaError::runtime)?;
+            this.check_write_permission(&new)
+                .map_err(LuaError::runtime)?;
+            std::fs::rename(&old, &new).into_lua_err()?;
+            Ok(())
+        });
+
+        methods.add_method("exists", |_, this, path: String| {
+            match this.check_read_permission(&path) {
+                Ok(canonical) => Ok(canonical.exists()),
+                // If the file doesn't exist, canonicalize may fail, but that's ok
+                Err(_) => Ok(false),
+            }
+        });
+
+        methods.add_method("list", |vm, this, path: String| {
+            let canonical = this
+                .check_read_permission(&path)
+                .map_err(LuaError::runtime)?;
+            let entries = std::fs::read_dir(&canonical).into_lua_err()?;
+            let table = vm.create_table()?;
+            let mut i = 1;
+            for entry in entries {
+                let entry = entry.into_lua_err()?;
+                let name = entry.file_name().to_string_lossy().to_string();
+                table.set(i, name)?;
+                i += 1;
+            }
+            Ok(table)
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write as _;
+
+    use serde_json::json;
+    use tempfile::{NamedTempFile, TempDir};
+    use tokio::io::empty;
+
+    use crate::{
+        Runner, State,
+        permission::{
+            EnvPermissions, NetPermissions, Permissions, ReadPermissions, WritePermissions,
+        },
+    };
+
+    /// Create a `Permissions::Some` with specific read/write permissions and permissive env/net.
+    fn fs_permissions(read: ReadPermissions, write: WritePermissions) -> Permissions {
+        Permissions::Some {
+            env: EnvPermissions::All {
+                denied: Default::default(),
+            },
+            net: NetPermissions::All {
+                denied: Default::default(),
+            },
+            read,
+            write,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_open_read() {
+        let mut tmp = NamedTempFile::new().expect("create temp file");
+        write!(tmp, "hello world").expect("write temp file");
+        let path = tmp.path().to_string_lossy().to_string();
+        let dir = tmp.path().parent().expect("parent dir").to_path_buf();
+
+        let source = include_str!("../fixtures/bindings/fs/open-read.lua");
+        let perm = fs_permissions(
+            ReadPermissions::Some {
+                allowed: [dir].into_iter().collect(),
+                denied: Default::default(),
+            },
+            WritePermissions::Some {
+                allowed: Default::default(),
+                denied: Default::default(),
+            },
+        );
+        let runner = Runner::builder(source, empty())
+            .permissions(perm)
+            .build()
+            .expect("build runner");
+        let state = State::builder().state(json!(path)).build();
+        let result = runner.invoke().state(state).call().await.expect("invoke");
+        assert_eq!(json!("hello world"), result.result.expect("result"));
+    }
+
+    #[tokio::test]
+    async fn test_open_write() {
+        let tmp = NamedTempFile::new().expect("create temp file");
+        let path = tmp.path().to_string_lossy().to_string();
+        let dir = tmp.path().parent().expect("parent dir").to_path_buf();
+
+        let source = include_str!("../fixtures/bindings/fs/open-write.lua");
+        let perm = fs_permissions(
+            ReadPermissions::Some {
+                allowed: [dir.clone()].into_iter().collect(),
+                denied: Default::default(),
+            },
+            WritePermissions::Some {
+                allowed: [dir].into_iter().collect(),
+                denied: Default::default(),
+            },
+        );
+        let runner = Runner::builder(source, empty())
+            .permissions(perm)
+            .build()
+            .expect("build runner");
+        let state = State::builder().state(json!(path)).build();
+        let result = runner.invoke().state(state).call().await.expect("invoke");
+        assert_eq!(json!("hello from lua"), result.result.expect("result"));
+    }
+
+    #[tokio::test]
+    async fn test_open_append() {
+        let mut tmp = NamedTempFile::new().expect("create temp file");
+        write!(tmp, "first").expect("write temp file");
+        let path = tmp.path().to_string_lossy().to_string();
+        let dir = tmp.path().parent().expect("parent dir").to_path_buf();
+
+        let source = include_str!("../fixtures/bindings/fs/open-append.lua");
+        let perm = fs_permissions(
+            ReadPermissions::Some {
+                allowed: [dir.clone()].into_iter().collect(),
+                denied: Default::default(),
+            },
+            WritePermissions::Some {
+                allowed: [dir].into_iter().collect(),
+                denied: Default::default(),
+            },
+        );
+        let runner = Runner::builder(source, empty())
+            .permissions(perm)
+            .build()
+            .expect("build runner");
+        let state = State::builder().state(json!(path)).build();
+        let result = runner.invoke().state(state).call().await.expect("invoke");
+        assert_eq!(json!("firstsecond"), result.result.expect("result"));
+    }
+
+    #[tokio::test]
+    async fn test_read_line() {
+        let mut tmp = NamedTempFile::new().expect("create temp file");
+        write!(tmp, "line1\nline2\nline3").expect("write temp file");
+        let path = tmp.path().to_string_lossy().to_string();
+        let dir = tmp.path().parent().expect("parent dir").to_path_buf();
+
+        let source = include_str!("../fixtures/bindings/fs/read-line.lua");
+        let perm = fs_permissions(
+            ReadPermissions::Some {
+                allowed: [dir].into_iter().collect(),
+                denied: Default::default(),
+            },
+            WritePermissions::Some {
+                allowed: Default::default(),
+                denied: Default::default(),
+            },
+        );
+        let runner = Runner::builder(source, empty())
+            .permissions(perm)
+            .build()
+            .expect("build runner");
+        let state = State::builder().state(json!(path)).build();
+        let result = runner.invoke().state(state).call().await.expect("invoke");
+        assert_eq!(
+            json!(["line1", "line2", "line3"]),
+            result.result.expect("result")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_read_bytes() {
+        let mut tmp = NamedTempFile::new().expect("create temp file");
+        write!(tmp, "abcdefghij").expect("write temp file");
+        let path = tmp.path().to_string_lossy().to_string();
+        let dir = tmp.path().parent().expect("parent dir").to_path_buf();
+
+        let source = include_str!("../fixtures/bindings/fs/read-bytes.lua");
+        let perm = fs_permissions(
+            ReadPermissions::Some {
+                allowed: [dir].into_iter().collect(),
+                denied: Default::default(),
+            },
+            WritePermissions::Some {
+                allowed: Default::default(),
+                denied: Default::default(),
+            },
+        );
+        let runner = Runner::builder(source, empty())
+            .permissions(perm)
+            .build()
+            .expect("build runner");
+        let state = State::builder().state(json!(path)).build();
+        let result = runner.invoke().state(state).call().await.expect("invoke");
+        assert_eq!(json!("abcde"), result.result.expect("result"));
+    }
+
+    #[tokio::test]
+    async fn test_lines() {
+        let mut tmp = NamedTempFile::new().expect("create temp file");
+        write!(tmp, "a\nb\nc").expect("write temp file");
+        let path = tmp.path().to_string_lossy().to_string();
+        let dir = tmp.path().parent().expect("parent dir").to_path_buf();
+
+        let source = include_str!("../fixtures/bindings/fs/lines.lua");
+        let perm = fs_permissions(
+            ReadPermissions::Some {
+                allowed: [dir].into_iter().collect(),
+                denied: Default::default(),
+            },
+            WritePermissions::Some {
+                allowed: Default::default(),
+                denied: Default::default(),
+            },
+        );
+        let runner = Runner::builder(source, empty())
+            .permissions(perm)
+            .build()
+            .expect("build runner");
+        let state = State::builder().state(json!(path)).build();
+        let result = runner.invoke().state(state).call().await.expect("invoke");
+        assert_eq!(json!(["a", "b", "c"]), result.result.expect("result"));
+    }
+
+    #[tokio::test]
+    async fn test_lines_shorthand() {
+        let mut tmp = NamedTempFile::new().expect("create temp file");
+        write!(tmp, "x\ny\nz").expect("write temp file");
+        let path = tmp.path().to_string_lossy().to_string();
+        let dir = tmp.path().parent().expect("parent dir").to_path_buf();
+
+        let source = include_str!("../fixtures/bindings/fs/lines-shorthand.lua");
+        let perm = fs_permissions(
+            ReadPermissions::Some {
+                allowed: [dir].into_iter().collect(),
+                denied: Default::default(),
+            },
+            WritePermissions::Some {
+                allowed: Default::default(),
+                denied: Default::default(),
+            },
+        );
+        let runner = Runner::builder(source, empty())
+            .permissions(perm)
+            .build()
+            .expect("build runner");
+        let state = State::builder().state(json!(path)).build();
+        let result = runner.invoke().state(state).call().await.expect("invoke");
+        assert_eq!(json!(["x", "y", "z"]), result.result.expect("result"));
+    }
+
+    #[tokio::test]
+    async fn test_seek() {
+        let mut tmp = NamedTempFile::new().expect("create temp file");
+        write!(tmp, "abcdefghij").expect("write temp file");
+        let path = tmp.path().to_string_lossy().to_string();
+        let dir = tmp.path().parent().expect("parent dir").to_path_buf();
+
+        let source = include_str!("../fixtures/bindings/fs/seek.lua");
+        let perm = fs_permissions(
+            ReadPermissions::Some {
+                allowed: [dir].into_iter().collect(),
+                denied: Default::default(),
+            },
+            WritePermissions::Some {
+                allowed: Default::default(),
+                denied: Default::default(),
+            },
+        );
+        let runner = Runner::builder(source, empty())
+            .permissions(perm)
+            .build()
+            .expect("build runner");
+        let state = State::builder().state(json!(path)).build();
+        let result = runner.invoke().state(state).call().await.expect("invoke");
+        assert_eq!(json!("fghij"), result.result.expect("result"));
+    }
+
+    #[tokio::test]
+    async fn test_type() {
+        let mut tmp = NamedTempFile::new().expect("create temp file");
+        write!(tmp, "test").expect("write temp file");
+        let path = tmp.path().to_string_lossy().to_string();
+        let dir = tmp.path().parent().expect("parent dir").to_path_buf();
+
+        let source = include_str!("../fixtures/bindings/fs/type.lua");
+        let perm = fs_permissions(
+            ReadPermissions::Some {
+                allowed: [dir].into_iter().collect(),
+                denied: Default::default(),
+            },
+            WritePermissions::Some {
+                allowed: Default::default(),
+                denied: Default::default(),
+            },
+        );
+        let runner = Runner::builder(source, empty())
+            .permissions(perm)
+            .build()
+            .expect("build runner");
+        let state = State::builder().state(json!(path)).build();
+        runner
+            .invoke()
+            .state(state)
+            .call()
+            .await
+            .expect("invoke")
+            .result
+            .expect("result");
+    }
+
+    #[tokio::test]
+    async fn test_remove() {
+        let tmp = NamedTempFile::new().expect("create temp file");
+        let path = tmp.path().to_string_lossy().to_string();
+        let dir = tmp.path().parent().expect("parent dir").to_path_buf();
+        // Keep the path but drop the handle so the file still exists
+        let path_buf = tmp.path().to_path_buf();
+        drop(tmp);
+        // Recreate file since NamedTempFile deletes on drop
+        std::fs::write(&path_buf, "to delete").expect("write file");
+
+        let source = include_str!("../fixtures/bindings/fs/remove.lua");
+        let perm = fs_permissions(
+            ReadPermissions::Some {
+                allowed: Default::default(),
+                denied: Default::default(),
+            },
+            WritePermissions::Some {
+                allowed: [dir].into_iter().collect(),
+                denied: Default::default(),
+            },
+        );
+        let runner = Runner::builder(source, empty())
+            .permissions(perm)
+            .build()
+            .expect("build runner");
+        let state = State::builder().state(json!(path)).build();
+        runner
+            .invoke()
+            .state(state)
+            .call()
+            .await
+            .expect("invoke")
+            .result
+            .expect("result");
+        assert!(!path_buf.exists(), "file should be deleted");
+    }
+
+    #[tokio::test]
+    async fn test_rename() {
+        let dir = TempDir::new().expect("create temp dir");
+        let old_path = dir.path().join("old.txt");
+        let new_path = dir.path().join("new.txt");
+        std::fs::write(&old_path, "content").expect("write file");
+
+        let source = include_str!("../fixtures/bindings/fs/rename.lua");
+        let canonical_dir = std::fs::canonicalize(dir.path()).expect("canonicalize");
+        let perm = fs_permissions(
+            ReadPermissions::Some {
+                allowed: Default::default(),
+                denied: Default::default(),
+            },
+            WritePermissions::Some {
+                allowed: [canonical_dir].into_iter().collect(),
+                denied: Default::default(),
+            },
+        );
+        let runner = Runner::builder(source, empty())
+            .permissions(perm)
+            .build()
+            .expect("build runner");
+        let state = State::builder()
+            .state(json!({
+                "old": old_path.to_string_lossy(),
+                "new": new_path.to_string_lossy(),
+            }))
+            .build();
+        runner
+            .invoke()
+            .state(state)
+            .call()
+            .await
+            .expect("invoke")
+            .result
+            .expect("result");
+        assert!(!old_path.exists(), "old file should not exist");
+        assert!(new_path.exists(), "new file should exist");
+        assert_eq!(std::fs::read_to_string(&new_path).expect("read"), "content");
+    }
+
+    #[tokio::test]
+    async fn test_exists() {
+        let tmp = NamedTempFile::new().expect("create temp file");
+        let path = tmp.path().to_string_lossy().to_string();
+        let dir = tmp.path().parent().expect("parent dir").to_path_buf();
+
+        let source = include_str!("../fixtures/bindings/fs/exists.lua");
+        let perm = fs_permissions(
+            ReadPermissions::Some {
+                allowed: [dir].into_iter().collect(),
+                denied: Default::default(),
+            },
+            WritePermissions::Some {
+                allowed: Default::default(),
+                denied: Default::default(),
+            },
+        );
+        let runner = Runner::builder(source, empty())
+            .permissions(perm)
+            .build()
+            .expect("build runner");
+        let state = State::builder().state(json!(path)).build();
+        runner
+            .invoke()
+            .state(state)
+            .call()
+            .await
+            .expect("invoke")
+            .result
+            .expect("result");
+    }
+
+    #[tokio::test]
+    async fn test_list() {
+        let dir = TempDir::new().expect("create temp dir");
+        std::fs::write(dir.path().join("a.txt"), "").expect("write a");
+        std::fs::write(dir.path().join("b.txt"), "").expect("write b");
+        let path = dir.path().to_string_lossy().to_string();
+        let canonical_dir = std::fs::canonicalize(dir.path()).expect("canonicalize");
+
+        let source = include_str!("../fixtures/bindings/fs/list.lua");
+        let perm = fs_permissions(
+            ReadPermissions::Some {
+                allowed: [canonical_dir].into_iter().collect(),
+                denied: Default::default(),
+            },
+            WritePermissions::Some {
+                allowed: Default::default(),
+                denied: Default::default(),
+            },
+        );
+        let runner = Runner::builder(source, empty())
+            .permissions(perm)
+            .build()
+            .expect("build runner");
+        let state = State::builder().state(json!(path)).build();
+        runner
+            .invoke()
+            .state(state)
+            .call()
+            .await
+            .expect("invoke")
+            .result
+            .expect("result");
+    }
+
+    #[tokio::test]
+    async fn test_permission_denied() {
+        let source = include_str!("../fixtures/bindings/fs/permission-denied.lua");
+        // No permissions granted
+        let runner = Runner::builder(source, empty())
+            .build()
+            .expect("build runner");
+        runner
+            .invoke()
+            .call()
+            .await
+            .expect("invoke")
+            .result
+            .expect("result");
+    }
+
+    #[tokio::test]
+    async fn test_closed_file() {
+        let mut tmp = NamedTempFile::new().expect("create temp file");
+        write!(tmp, "test").expect("write temp file");
+        let path = tmp.path().to_string_lossy().to_string();
+        let dir = tmp.path().parent().expect("parent dir").to_path_buf();
+
+        let source = include_str!("../fixtures/bindings/fs/closed-file.lua");
+        let perm = fs_permissions(
+            ReadPermissions::Some {
+                allowed: [dir].into_iter().collect(),
+                denied: Default::default(),
+            },
+            WritePermissions::Some {
+                allowed: Default::default(),
+                denied: Default::default(),
+            },
+        );
+        let runner = Runner::builder(source, empty())
+            .permissions(perm)
+            .build()
+            .expect("build runner");
+        let state = State::builder().state(json!(path)).build();
+        runner
+            .invoke()
+            .state(state)
+            .call()
+            .await
+            .expect("invoke")
+            .result
+            .expect("result");
+    }
+}

--- a/src/bindings/mod.rs
+++ b/src/bindings/mod.rs
@@ -34,6 +34,7 @@ pub(crate) use define_codec_binding;
 
 pub(crate) mod coroutine;
 pub(crate) mod crypto;
+pub(crate) mod fs;
 pub(crate) mod globals;
 pub(crate) mod http;
 pub(crate) mod io;

--- a/src/fixtures/bindings/fs/closed-file.lua
+++ b/src/fixtures/bindings/fs/closed-file.lua
@@ -1,0 +1,22 @@
+function closed_file(ctx)
+  local fs = require("@lmb/fs")
+  local f = fs:open(ctx.state, "r")
+  f:close()
+
+  -- read on closed file should error
+  local ok, err = pcall(function() f:read("*a") end)
+  assert(not ok, "Expected error on read after close")
+  assert(string.find(tostring(err), "closed file"), "Expected 'closed file' in error: " .. tostring(err))
+
+  -- write on closed file should error
+  ok, err = pcall(function() f:write("test") end)
+  assert(not ok, "Expected error on write after close")
+  assert(string.find(tostring(err), "closed file"), "Expected 'closed file' in error: " .. tostring(err))
+
+  -- close again should error
+  ok, err = pcall(function() f:close() end)
+  assert(not ok, "Expected error on double close")
+  assert(string.find(tostring(err), "closed file"), "Expected 'closed file' in error: " .. tostring(err))
+end
+
+return closed_file

--- a/src/fixtures/bindings/fs/exists.lua
+++ b/src/fixtures/bindings/fs/exists.lua
@@ -1,0 +1,7 @@
+function exists_test(ctx)
+  local fs = require("@lmb/fs")
+  assert(fs:exists(ctx.state) == true, "Expected file to exist")
+  assert(fs:exists("/nonexistent/path/abc123") == false, "Expected nonexistent path to return false")
+end
+
+return exists_test

--- a/src/fixtures/bindings/fs/flush.lua
+++ b/src/fixtures/bindings/fs/flush.lua
@@ -1,0 +1,13 @@
+function flush_test(ctx)
+  local fs = require("@lmb/fs")
+  local path = ctx.state
+  local f = fs:open(path, "w")
+  f:write("flushed")
+  f:flush()
+  f:close()
+  local f2 = fs:open(path, "r")
+  local content = f2:read("*a")
+  f2:close()
+  return content
+end
+return flush_test

--- a/src/fixtures/bindings/fs/lines-shorthand.lua
+++ b/src/fixtures/bindings/fs/lines-shorthand.lua
@@ -1,0 +1,10 @@
+function lines_shorthand(ctx)
+  local fs = require("@lmb/fs")
+  local result = {}
+  for line in fs:lines(ctx.state) do
+    table.insert(result, line)
+  end
+  return result
+end
+
+return lines_shorthand

--- a/src/fixtures/bindings/fs/lines.lua
+++ b/src/fixtures/bindings/fs/lines.lua
@@ -1,0 +1,12 @@
+function lines_test(ctx)
+  local fs = require("@lmb/fs")
+  local f = fs:open(ctx.state, "r")
+  local result = {}
+  for line in f:lines() do
+    table.insert(result, line)
+  end
+  f:close()
+  return result
+end
+
+return lines_test

--- a/src/fixtures/bindings/fs/list.lua
+++ b/src/fixtures/bindings/fs/list.lua
@@ -1,0 +1,10 @@
+function list_test(ctx)
+  local fs = require("@lmb/fs")
+  local entries = fs:list(ctx.state)
+  assert(#entries == 2, "Expected 2 entries, got " .. #entries)
+  table.sort(entries)
+  assert(entries[1] == "a.txt", "Expected first entry to be 'a.txt', got " .. entries[1])
+  assert(entries[2] == "b.txt", "Expected second entry to be 'b.txt', got " .. entries[2])
+end
+
+return list_test

--- a/src/fixtures/bindings/fs/open-ap.lua
+++ b/src/fixtures/bindings/fs/open-ap.lua
@@ -1,0 +1,11 @@
+function open_ap(ctx)
+  local fs = require("@lmb/fs")
+  local path = ctx.state
+  local f = fs:open(path, "a+")
+  f:write(" appended")
+  f:seek("set", 0)
+  local content = f:read("*a")
+  f:close()
+  return content
+end
+return open_ap

--- a/src/fixtures/bindings/fs/open-append.lua
+++ b/src/fixtures/bindings/fs/open-append.lua
@@ -1,0 +1,13 @@
+function open_append(ctx)
+  local fs = require("@lmb/fs")
+  local f = fs:open(ctx.state, "a")
+  f:write("second")
+  f:close()
+
+  local f2 = fs:open(ctx.state, "r")
+  local content = f2:read("*a")
+  f2:close()
+  return content
+end
+
+return open_append

--- a/src/fixtures/bindings/fs/open-invalid-mode.lua
+++ b/src/fixtures/bindings/fs/open-invalid-mode.lua
@@ -1,0 +1,6 @@
+function open_invalid(ctx)
+  local fs = require("@lmb/fs")
+  local f, err = fs:open(ctx.state, "x")
+  return err
+end
+return open_invalid

--- a/src/fixtures/bindings/fs/open-nonexistent.lua
+++ b/src/fixtures/bindings/fs/open-nonexistent.lua
@@ -1,0 +1,6 @@
+function open_nonexistent(ctx)
+  local fs = require("@lmb/fs")
+  local f, err = fs:open(ctx.state .. "/nonexistent.txt", "r")
+  return err ~= nil
+end
+return open_nonexistent

--- a/src/fixtures/bindings/fs/open-read.lua
+++ b/src/fixtures/bindings/fs/open-read.lua
@@ -1,0 +1,9 @@
+function open_read(ctx)
+  local fs = require("@lmb/fs")
+  local f = fs:open(ctx.state, "r")
+  local content = f:read("*a")
+  f:close()
+  return content
+end
+
+return open_read

--- a/src/fixtures/bindings/fs/open-rw.lua
+++ b/src/fixtures/bindings/fs/open-rw.lua
@@ -1,0 +1,14 @@
+function open_rw(ctx)
+  local fs = require("@lmb/fs")
+  local path = ctx.state
+  local f = fs:open(path, "r+")
+  local content = f:read("*a")
+  f:seek("set", 0)
+  f:write("XX")
+  f:close()
+  local f2 = fs:open(path, "r")
+  local result = f2:read("*a")
+  f2:close()
+  return { original = content, modified = result }
+end
+return open_rw

--- a/src/fixtures/bindings/fs/open-wp.lua
+++ b/src/fixtures/bindings/fs/open-wp.lua
@@ -1,0 +1,11 @@
+function open_wp(ctx)
+  local fs = require("@lmb/fs")
+  local path = ctx.state
+  local f = fs:open(path, "w+")
+  f:write("hello w+")
+  f:seek("set", 0)
+  local content = f:read("*a")
+  f:close()
+  return content
+end
+return open_wp

--- a/src/fixtures/bindings/fs/open-write.lua
+++ b/src/fixtures/bindings/fs/open-write.lua
@@ -1,0 +1,13 @@
+function open_write(ctx)
+  local fs = require("@lmb/fs")
+  local f = fs:open(ctx.state, "w")
+  f:write("hello from lua")
+  f:close()
+
+  local f2 = fs:open(ctx.state, "r")
+  local content = f2:read("*a")
+  f2:close()
+  return content
+end
+
+return open_write

--- a/src/fixtures/bindings/fs/permission-denied.lua
+++ b/src/fixtures/bindings/fs/permission-denied.lua
@@ -1,0 +1,11 @@
+function permission_denied()
+  local fs = require("@lmb/fs")
+
+  -- open should return nil + error when no permissions
+  local f, err = fs:open("/tmp/test.txt", "r")
+  assert(f == nil, "Expected nil handle when permission denied")
+  assert(err ~= nil, "Expected error message when permission denied")
+  assert(string.find(err, "permission denied"), "Expected 'permission denied' in error: " .. err)
+end
+
+return permission_denied

--- a/src/fixtures/bindings/fs/read-bytes-eof.lua
+++ b/src/fixtures/bindings/fs/read-bytes-eof.lua
@@ -1,0 +1,9 @@
+function read_bytes_eof(ctx)
+  local fs = require("@lmb/fs")
+  local f = fs:open(ctx.state, "r")
+  -- Read past end of empty file
+  local data = f:read(10)
+  f:close()
+  return data == nil
+end
+return read_bytes_eof

--- a/src/fixtures/bindings/fs/read-bytes-partial.lua
+++ b/src/fixtures/bindings/fs/read-bytes-partial.lua
@@ -1,0 +1,9 @@
+function read_bytes_partial(ctx)
+  local fs = require("@lmb/fs")
+  local f = fs:open(ctx.state, "r")
+  -- Request more bytes than available, should truncate
+  local data = f:read(100)
+  f:close()
+  return data
+end
+return read_bytes_partial

--- a/src/fixtures/bindings/fs/read-bytes.lua
+++ b/src/fixtures/bindings/fs/read-bytes.lua
@@ -1,0 +1,9 @@
+function read_bytes(ctx)
+  local fs = require("@lmb/fs")
+  local f = fs:open(ctx.state, "r")
+  local bytes = f:read(5)
+  f:close()
+  return bytes
+end
+
+return read_bytes

--- a/src/fixtures/bindings/fs/read-invalid-format.lua
+++ b/src/fixtures/bindings/fs/read-invalid-format.lua
@@ -1,0 +1,8 @@
+function read_invalid(ctx)
+  local fs = require("@lmb/fs")
+  local f = fs:open(ctx.state, "r")
+  local ok, err = pcall(function() f:read("*z") end)
+  f:close()
+  return tostring(err)
+end
+return read_invalid

--- a/src/fixtures/bindings/fs/read-line.lua
+++ b/src/fixtures/bindings/fs/read-line.lua
@@ -1,0 +1,14 @@
+function read_line(ctx)
+  local fs = require("@lmb/fs")
+  local f = fs:open(ctx.state, "r")
+  local lines = {}
+  while true do
+    local line = f:read("*l")
+    if line == nil then break end
+    table.insert(lines, line)
+  end
+  f:close()
+  return lines
+end
+
+return read_line

--- a/src/fixtures/bindings/fs/read-number-eof.lua
+++ b/src/fixtures/bindings/fs/read-number-eof.lua
@@ -1,0 +1,9 @@
+function read_number_eof(ctx)
+  local fs = require("@lmb/fs")
+  local f = fs:open(ctx.state, "r")
+  local n = f:read("*n")
+  f:close()
+  -- n should be nil for empty file
+  return n == nil
+end
+return read_number_eof

--- a/src/fixtures/bindings/fs/read-number-nan.lua
+++ b/src/fixtures/bindings/fs/read-number-nan.lua
@@ -1,0 +1,9 @@
+function read_number_nan(ctx)
+  local fs = require("@lmb/fs")
+  local f = fs:open(ctx.state, "r")
+  local n = f:read("*n")
+  f:close()
+  -- n should be nil for non-numeric content
+  return n == nil
+end
+return read_number_nan

--- a/src/fixtures/bindings/fs/read-number.lua
+++ b/src/fixtures/bindings/fs/read-number.lua
@@ -1,0 +1,8 @@
+function read_number(ctx)
+  local fs = require("@lmb/fs")
+  local f = fs:open(ctx.state, "r")
+  local n = f:read("*n")
+  f:close()
+  return n
+end
+return read_number

--- a/src/fixtures/bindings/fs/read-permission-denied-some.lua
+++ b/src/fixtures/bindings/fs/read-permission-denied-some.lua
@@ -1,0 +1,6 @@
+function read_denied_some(ctx)
+  local fs = require("@lmb/fs")
+  local f, err = fs:open(ctx.state, "r")
+  return tostring(err)
+end
+return read_denied_some

--- a/src/fixtures/bindings/fs/remove.lua
+++ b/src/fixtures/bindings/fs/remove.lua
@@ -1,0 +1,6 @@
+function remove_test(ctx)
+  local fs = require("@lmb/fs")
+  fs:remove(ctx.state)
+end
+
+return remove_test

--- a/src/fixtures/bindings/fs/rename.lua
+++ b/src/fixtures/bindings/fs/rename.lua
@@ -1,0 +1,6 @@
+function rename_test(ctx)
+  local fs = require("@lmb/fs")
+  fs:rename(ctx.state.old, ctx.state.new)
+end
+
+return rename_test

--- a/src/fixtures/bindings/fs/seek-cur-end.lua
+++ b/src/fixtures/bindings/fs/seek-cur-end.lua
@@ -1,0 +1,13 @@
+function seek_cur_end(ctx)
+  local fs = require("@lmb/fs")
+  local f = fs:open(ctx.state, "r")
+  -- seek to end
+  local size = f:seek("end", 0)
+  -- seek back from current
+  f:seek("set", 0)
+  f:seek("cur", 2)
+  local rest = f:read("*a")
+  f:close()
+  return { size = size, rest = rest }
+end
+return seek_cur_end

--- a/src/fixtures/bindings/fs/seek-invalid.lua
+++ b/src/fixtures/bindings/fs/seek-invalid.lua
@@ -1,0 +1,8 @@
+function seek_invalid(ctx)
+  local fs = require("@lmb/fs")
+  local f = fs:open(ctx.state, "r")
+  local ok, err = pcall(function() f:seek("bad", 0) end)
+  f:close()
+  return tostring(err)
+end
+return seek_invalid

--- a/src/fixtures/bindings/fs/seek.lua
+++ b/src/fixtures/bindings/fs/seek.lua
@@ -1,0 +1,10 @@
+function seek_test(ctx)
+  local fs = require("@lmb/fs")
+  local f = fs:open(ctx.state, "r")
+  f:seek("set", 5)
+  local content = f:read("*a")
+  f:close()
+  return content
+end
+
+return seek_test

--- a/src/fixtures/bindings/fs/type.lua
+++ b/src/fixtures/bindings/fs/type.lua
@@ -1,0 +1,17 @@
+function type_test(ctx)
+  local fs = require("@lmb/fs")
+
+  -- non-file value
+  assert(fs.type("hello") == nil, "Expected nil for string")
+  assert(fs.type(123) == nil, "Expected nil for number")
+
+  -- open file handle
+  local f = fs:open(ctx.state, "r")
+  assert(fs.type(f) == "file", "Expected 'file' for open handle")
+
+  -- closed file handle
+  f:close()
+  assert(fs.type(f) == "closed file", "Expected 'closed file' for closed handle")
+end
+
+return type_test

--- a/src/fixtures/bindings/fs/write-invalid.lua
+++ b/src/fixtures/bindings/fs/write-invalid.lua
@@ -1,0 +1,8 @@
+function write_invalid(ctx)
+  local fs = require("@lmb/fs")
+  local f = fs:open(ctx.state, "w")
+  local ok, err = pcall(function() f:write(true) end)
+  f:close()
+  return tostring(err)
+end
+return write_invalid

--- a/src/fixtures/bindings/fs/write-no-permissions.lua
+++ b/src/fixtures/bindings/fs/write-no-permissions.lua
@@ -1,0 +1,6 @@
+function write_no_perms(ctx)
+  local fs = require("@lmb/fs")
+  local f, err = fs:open(ctx.state, "w")
+  return tostring(err)
+end
+return write_no_perms

--- a/src/fixtures/bindings/fs/write-number.lua
+++ b/src/fixtures/bindings/fs/write-number.lua
@@ -1,0 +1,13 @@
+function write_number(ctx)
+  local fs = require("@lmb/fs")
+  local path = ctx.state
+  local f = fs:open(path, "w")
+  f:write(42)
+  f:write(3.14)
+  f:close()
+  local f2 = fs:open(path, "r")
+  local content = f2:read("*a")
+  f2:close()
+  return content
+end
+return write_number

--- a/src/fixtures/bindings/fs/write-permission-denied.lua
+++ b/src/fixtures/bindings/fs/write-permission-denied.lua
@@ -1,0 +1,6 @@
+function write_denied(ctx)
+  local fs = require("@lmb/fs")
+  local f, err = fs:open(ctx.state, "w")
+  return err
+end
+return write_denied

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,6 +236,12 @@ impl Runner {
             vm.register_module("@lmb/coroutine", bindings::coroutine::CoroutineBinding {})?;
             vm.register_module("@lmb/crypto", bindings::crypto::CryptoBinding {})?;
             vm.register_module(
+                "@lmb/fs",
+                bindings::fs::FsBinding::builder()
+                    .maybe_permissions(permissions.clone())
+                    .build(),
+            )?;
+            vm.register_module(
                 "@lmb/http",
                 bindings::http::HttpBinding::builder()
                     .maybe_permissions(permissions.clone())


### PR DESCRIPTION
## Summary

Closes #160.

- Add `@lmb/fs` module providing Lua-native file I/O: `open`, `read`, `write`, `lines`, `seek`, `flush`, `close`, `remove`, `rename`, `exists`, `list`
- Extend permission system with `ReadPermissions` / `WritePermissions` enums and path-level allow/deny control (exact match + directory inheritance)
- Add 6 CLI flags: `--allow-all-read`, `--allow-read`, `--deny-read`, `--allow-all-write`, `--allow-write`, `--deny-write`
- Add 34 Lua test fixtures and corresponding Rust tests (97% coverage on `fs.rs`)
- Add executable Filesystem section to guided tour with temp-dir sandboxing support in the test harness

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` — all tests pass (including guided tour fs examples)
- [x] `fs.rs` coverage at 97.11%
- [x] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)