### PR TITLE
refactor: lazy-init reqwest::Client via OnceLock in HttpBinding

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,7 +246,7 @@ impl Runner {
                 bindings::http::HttpBinding::builder()
                     .maybe_permissions(permissions.clone())
                     .maybe_timeout(http_timeout)
-                    .build()?,
+                    .build(),
             )?;
             vm.register_module("@lmb/json", bindings::json::JsonBinding {})?;
             vm.register_module("@lmb/json-path", bindings::json_path::JsonPathBinding {})?;


### PR DESCRIPTION
## Summary
- Defer `reqwest::Client` construction in `HttpBinding` until the first `fetch()` call using `OnceLock`, instead of eagerly building it at VM startup.
- `HttpBinding::new()` is now infallible (returns `Self` instead of `LmbResult<Self>`), removing the `?` at the call site in `lib.rs`.
- Scripts that never use the HTTP module no longer pay the allocation cost.

## Test plan
- [x] All 303 existing tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)