### PR TITLE
Remove crypto-common direct dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1922,7 +1922,6 @@ dependencies = [
  "clio",
  "crc32fast",
  "criterion",
- "crypto-common",
  "curl-parser",
  "deadpool",
  "des",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ cbc = { version = "0.1.2", features = ["alloc"] }
 clap = { version = "4.5.58", features = ["derive", "env"] }
 clio = { version = "0.3.5", features = ["clap-parse"] }
 crc32fast = "1.5.0"
-crypto-common = "0.1.6"
 deadpool = "0.12.3"
 des = "0.8.1"
 ecb = "0.1.2"
@@ -126,7 +125,7 @@ checked_conversions = "warn"
 dbg_macro = "warn"
 debug_assert_with_mut_call = "warn"
 doc_markdown = "warn"
-empty_enum = "warn"
+empty_enums = "warn"
 enum_glob_use = "warn"
 exit = "warn"
 expl_impl_clone_on_copy = "warn"

--- a/src/bindings/crypto.rs
+++ b/src/bindings/crypto.rs
@@ -60,7 +60,9 @@
 
 use std::{fmt, sync::Arc};
 
-use aes::cipher::{BlockDecryptMut as _, BlockEncryptMut as _, KeyInit, KeyIvInit as _, block_padding::Pkcs7};
+use aes::cipher::{
+    BlockDecryptMut as _, BlockEncryptMut as _, KeyInit, KeyIvInit as _, block_padding::Pkcs7,
+};
 use base64::prelude::*;
 use hmac::{Hmac, Mac};
 use md5::Md5;

--- a/src/bindings/crypto.rs
+++ b/src/bindings/crypto.rs
@@ -60,9 +60,8 @@
 
 use std::{fmt, sync::Arc};
 
-use aes::cipher::{BlockDecryptMut as _, BlockEncryptMut as _, block_padding::Pkcs7};
+use aes::cipher::{BlockDecryptMut as _, BlockEncryptMut as _, KeyInit, KeyIvInit as _, block_padding::Pkcs7};
 use base64::prelude::*;
-use crypto_common::{KeyInit, KeyIvInit as _};
 use hmac::{Hmac, Mac};
 use md5::Md5;
 use mlua::prelude::*;


### PR DESCRIPTION
## Summary
- Remove `crypto-common` as a direct dependency
- Use `KeyInit` and `KeyIvInit` traits re-exported from `cipher` crate instead
- Fix deprecated clippy lint name (`empty_enum` → `empty_enums`)

## Test plan
- [x] All 231 tests pass
- [x] Clippy passes with `-D warnings`
- [x] Code formatting is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)