### PR TITLE
feat: add `@lmb/time` module for `now_ms` and `parse`

### DIFF
--- a/docs/guided-tour.md
+++ b/docs/guided-tour.md
@@ -710,6 +710,38 @@ end
 return parse_path
 ```
 
+### Time
+
+The `@lmb/time` module provides time utilities not covered by Luau's built-in `os` library. While `os.time()` gives second-precision timestamps, `now_ms()` provides millisecond precision. The `parse()` function converts date strings to Unix timestamps using POSIX strptime format specifiers.
+
+```lua
+--[[
+--name = "Time"
+--]]
+function time_example()
+  local time = require("@lmb/time")
+
+  -- Millisecond precision timestamp
+  local ms = time.now_ms()
+  assert(ms > 0, "Expected positive timestamp")
+  assert(ms >= os.time() * 1000, "now_ms should be >= os.time() * 1000")
+
+  -- Parse date strings to Unix timestamps
+  local ts = time.parse("2026-02-09", "%Y-%m-%d")
+  assert(ts > 0, "Expected positive timestamp from parse")
+
+  -- Parse with time component
+  local ts2 = time.parse("2026-02-09 12:00:00", "%Y-%m-%d %H:%M:%S")
+  assert(ts2 > ts, "Timestamp with noon should be greater than midnight")
+
+  -- Epoch check
+  local epoch = time.parse("1970-01-01 00:00:00", "%Y-%m-%d %H:%M:%S")
+  assert(epoch == 0, "1970-01-01 00:00:00 should be epoch 0")
+end
+
+return time_example
+```
+
 ## Encoding and decoding
 
 ### JSON

--- a/docs/guided-tour.md
+++ b/docs/guided-tour.md
@@ -712,7 +712,7 @@ return parse_path
 
 ### Time
 
-The `@lmb/time` module provides time utilities not covered by Luau's built-in `os` library. While `os.time()` gives second-precision timestamps, `now_ms()` provides millisecond precision. The `parse()` function converts date strings to Unix timestamps using POSIX strptime format specifiers.
+The `@lmb/time` module provides time utilities not covered by Luau's built-in `os` library. While `os.time()` gives second-precision timestamps, `now_ms()` provides millisecond precision. The `parse()` function converts date strings to Unix timestamps — it auto-detects RFC 3339, ISO 8601, RFC 2822, and asctime formats, or accepts an explicit POSIX strptime format string.
 
 ```lua
 --[[
@@ -726,17 +726,17 @@ function time_example()
   assert(ms > 0, "Expected positive timestamp")
   assert(ms >= os.time() * 1000, "now_ms should be >= os.time() * 1000")
 
-  -- Parse date strings to Unix timestamps
-  local ts = time.parse("2026-02-09", "%Y-%m-%d")
-  assert(ts > 0, "Expected positive timestamp from parse")
+  -- Auto-detect format (RFC 3339 / ISO 8601)
+  local ts = time.parse("2026-02-09T12:00:00Z")
+  assert(ts > 0, "Expected positive timestamp from auto-detect")
 
-  -- Parse with time component
-  local ts2 = time.parse("2026-02-09 12:00:00", "%Y-%m-%d %H:%M:%S")
-  assert(ts2 > ts, "Timestamp with noon should be greater than midnight")
+  -- Auto-detect format (RFC 2822)
+  local ts2 = time.parse("Mon, 09 Feb 2026 12:00:00 +0000")
+  assert(ts2 == ts, "RFC 2822 should match RFC 3339")
 
-  -- Epoch check
-  local epoch = time.parse("1970-01-01 00:00:00", "%Y-%m-%d %H:%M:%S")
-  assert(epoch == 0, "1970-01-01 00:00:00 should be epoch 0")
+  -- Explicit format (strptime)
+  local ts3 = time.parse("2026-02-09", "%Y-%m-%d")
+  assert(ts3 > 0, "Expected positive timestamp from explicit format")
 end
 
 return time_example

--- a/src/bindings/mod.rs
+++ b/src/bindings/mod.rs
@@ -42,6 +42,7 @@ pub(crate) mod json;
 pub(crate) mod json_path;
 pub(crate) mod logging;
 pub(crate) mod store;
+pub(crate) mod time;
 pub(crate) mod toml;
 pub(crate) mod yaml;
 

--- a/src/bindings/time.rs
+++ b/src/bindings/time.rs
@@ -6,8 +6,17 @@
 //! # Available Methods
 //!
 //! - `now_ms()` - Returns current Unix timestamp in milliseconds (integer).
-//! - `parse(input, format)` - Parses a date string using POSIX strptime format specifiers
-//!   and returns a Unix timestamp in seconds (integer).
+//! - `parse(input [, format])` - Parses a date string and returns a Unix timestamp in seconds.
+//!   When `format` is provided, uses POSIX strptime format specifiers.
+//!   When omitted, auto-detects from supported formats (see below).
+//!
+//! # Auto-detected Formats
+//!
+//! When `format` is omitted, `parse` tries the following in order:
+//!
+//! 1. **RFC 3339 / RFC 9557 / ISO 8601** — `2026-02-09T12:00:00Z`, `2026-02-09 12:00:00+08:00`
+//! 2. **RFC 2822 / 5322 / 1123** — `Sat, 09 Feb 2026 12:00:00 +0000`
+//! 3. **asctime** — `Sat Feb  9 12:00:00 2026`
 //!
 //! # Example
 //!
@@ -17,15 +26,71 @@
 //! -- Millisecond precision timestamp
 //! local ms = time.now_ms()
 //!
-//! -- Parse date strings
+//! -- Auto-detect format
+//! local ts = time.parse("2026-02-09T12:00:00Z")
+//! local ts = time.parse("Sat, 09 Feb 2026 12:00:00 +0000")
+//!
+//! -- Explicit format
 //! local ts = time.parse("2026-02-09", "%Y-%m-%d")
-//! local ts2 = time.parse("2026-02-09 12:00:00", "%Y-%m-%d %H:%M:%S")
 //! ```
 
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use jiff::tz::TimeZone;
 use mlua::prelude::*;
+
+/// strptime formats for auto-detection, tried in order after jiff's built-in parser.
+const AUTO_FORMATS: &[&str] = &[
+    // RFC 2822 / 5322 / 1123
+    "%a, %d %b %Y %H:%M:%S %z",
+    // asctime
+    "%a %b %d %H:%M:%S %Y",
+];
+
+/// Convert a parsed strptime result to a Unix timestamp in seconds,
+/// falling back to UTC when no offset is present.
+fn broken_down_to_timestamp(tm: &jiff::fmt::strtime::BrokenDownTime) -> Option<i64> {
+    tm.to_timestamp()
+        .or_else(|_| {
+            tm.to_datetime()
+                .and_then(|dt| dt.to_zoned(TimeZone::UTC))
+                .map(|z| z.timestamp())
+        })
+        .ok()
+        .map(|ts| ts.as_second())
+}
+
+/// Try to parse a date string by auto-detecting the format.
+fn parse_auto(input: &str) -> Result<i64, String> {
+    // 1. jiff built-in parser (RFC 3339 / RFC 9557 / ISO 8601)
+    if let Ok(ts) = input.parse::<jiff::Timestamp>() {
+        return Ok(ts.as_second());
+    }
+    // Also try civil::DateTime for inputs without offset (e.g. "2026-02-09" or "2026-02-09 12:00:00")
+    if let Ok(dt) = input.parse::<jiff::civil::DateTime>() {
+        if let Ok(z) = dt.to_zoned(TimeZone::UTC) {
+            return Ok(z.timestamp().as_second());
+        }
+    }
+    if let Ok(d) = input.parse::<jiff::civil::Date>() {
+        if let Ok(z) = d.to_zoned(TimeZone::UTC) {
+            return Ok(z.timestamp().as_second());
+        }
+    }
+
+    // 2-3. Try strptime with known formats
+    for fmt in AUTO_FORMATS {
+        if let Ok(tm) = jiff::fmt::strtime::parse(fmt, input) {
+            if let Some(ts) = broken_down_to_timestamp(&tm) {
+                return Ok(ts);
+            }
+        }
+    }
+
+    Err(format!(
+        "failed to parse '{input}': no known format matched"
+    ))
+}
 
 /// Time binding that exposes time utilities to Lua.
 pub(crate) struct TimeBinding;
@@ -40,19 +105,20 @@ impl LuaUserData for TimeBinding {
             Ok(ms)
         });
 
-        methods.add_function("parse", |_, (input, format): (String, String)| {
-            let tm = jiff::fmt::strtime::parse(&format, &input).map_err(LuaError::external)?;
-            // Try to convert directly to timestamp (works when offset is present).
-            // Fall back to interpreting as UTC datetime.
-            let ts = tm
-                .to_timestamp()
-                .or_else(|_| {
-                    tm.to_datetime()
-                        .and_then(|dt| dt.to_zoned(TimeZone::UTC))
-                        .map(|z| z.timestamp())
-                })
-                .map_err(LuaError::external)?;
-            Ok(ts.as_second())
+        methods.add_function("parse", |_, (input, format): (String, Option<String>)| {
+            let ts = match format {
+                Some(fmt) => {
+                    let tm = jiff::fmt::strtime::parse(&fmt, &input)
+                        .map_err(LuaError::external)?;
+                    broken_down_to_timestamp(&tm).ok_or_else(|| {
+                        LuaError::external(format!(
+                            "failed to convert parsed date '{input}' to timestamp"
+                        ))
+                    })?
+                }
+                None => parse_auto(&input).map_err(LuaError::external)?,
+            };
+            Ok(ts)
         });
     }
 }

--- a/src/bindings/time.rs
+++ b/src/bindings/time.rs
@@ -108,8 +108,7 @@ impl LuaUserData for TimeBinding {
         methods.add_function("parse", |_, (input, format): (String, Option<String>)| {
             let ts = match format {
                 Some(fmt) => {
-                    let tm = jiff::fmt::strtime::parse(&fmt, &input)
-                        .map_err(LuaError::external)?;
+                    let tm = jiff::fmt::strtime::parse(&fmt, &input).map_err(LuaError::external)?;
                     broken_down_to_timestamp(&tm).ok_or_else(|| {
                         LuaError::external(format!(
                             "failed to convert parsed date '{input}' to timestamp"

--- a/src/bindings/time.rs
+++ b/src/bindings/time.rs
@@ -1,0 +1,72 @@
+//! Time utilities binding module.
+//!
+//! This module provides time utilities not covered by Luau's built-in `os` library.
+//! Import via `require("@lmb/time")`.
+//!
+//! # Available Methods
+//!
+//! - `now_ms()` - Returns current Unix timestamp in milliseconds (integer).
+//! - `parse(input, format)` - Parses a date string using POSIX strptime format specifiers
+//!   and returns a Unix timestamp in seconds (integer).
+//!
+//! # Example
+//!
+//! ```lua
+//! local time = require("@lmb/time")
+//!
+//! -- Millisecond precision timestamp
+//! local ms = time.now_ms()
+//!
+//! -- Parse date strings
+//! local ts = time.parse("2026-02-09", "%Y-%m-%d")
+//! local ts2 = time.parse("2026-02-09 12:00:00", "%Y-%m-%d %H:%M:%S")
+//! ```
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use jiff::tz::TimeZone;
+use mlua::prelude::*;
+
+/// Time binding that exposes time utilities to Lua.
+pub(crate) struct TimeBinding;
+
+impl LuaUserData for TimeBinding {
+    fn add_methods<M: LuaUserDataMethods<Self>>(methods: &mut M) {
+        methods.add_function("now_ms", |_, ()| {
+            let ms = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map_err(LuaError::external)?
+                .as_millis() as i64;
+            Ok(ms)
+        });
+
+        methods.add_function("parse", |_, (input, format): (String, String)| {
+            let tm = jiff::fmt::strtime::parse(&format, &input).map_err(LuaError::external)?;
+            // Try to convert directly to timestamp (works when offset is present).
+            // Fall back to interpreting as UTC datetime.
+            let ts = tm
+                .to_timestamp()
+                .or_else(|_| {
+                    tm.to_datetime()
+                        .and_then(|dt| dt.to_zoned(TimeZone::UTC))
+                        .map(|z| z.timestamp())
+                })
+                .map_err(LuaError::external)?;
+            Ok(ts.as_second())
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::io::empty;
+
+    use crate::Runner;
+
+    #[tokio::test]
+    async fn test_time() {
+        let source = include_str!("../fixtures/bindings/time.lua");
+        let runner = Runner::builder(source, empty()).build().unwrap();
+        runner.invoke().call().await.unwrap().result.unwrap();
+    }
+}

--- a/src/bindings/time.rs
+++ b/src/bindings/time.rs
@@ -66,16 +66,15 @@ fn parse_auto(input: &str) -> Result<i64, String> {
     if let Ok(ts) = input.parse::<jiff::Timestamp>() {
         return Ok(ts.as_second());
     }
-    // Also try civil::DateTime for inputs without offset (e.g. "2026-02-09" or "2026-02-09 12:00:00")
+    // Also try civil::DateTime for inputs without offset (e.g. "2026-02-09 12:00:00")
     if let Ok(dt) = input.parse::<jiff::civil::DateTime>() {
-        if let Ok(z) = dt.to_zoned(TimeZone::UTC) {
-            return Ok(z.timestamp().as_second());
-        }
+        let z = dt.to_zoned(TimeZone::UTC).map_err(|e| e.to_string())?;
+        return Ok(z.timestamp().as_second());
     }
+    // Also try civil::Date for date-only inputs (e.g. "2026-02-09")
     if let Ok(d) = input.parse::<jiff::civil::Date>() {
-        if let Ok(z) = d.to_zoned(TimeZone::UTC) {
-            return Ok(z.timestamp().as_second());
-        }
+        let z = d.to_zoned(TimeZone::UTC).map_err(|e| e.to_string())?;
+        return Ok(z.timestamp().as_second());
     }
 
     // 2-3. Try strptime with known formats

--- a/src/fixtures/bindings/time.lua
+++ b/src/fixtures/bindings/time.lua
@@ -1,0 +1,25 @@
+local time = require("@lmb/time")
+
+-- now_ms should return a positive integer
+local ms = time.now_ms()
+assert(type(ms) == "number", "now_ms should return a number")
+assert(ms > 0, "now_ms should return a positive number")
+
+-- now_ms should be greater than os.time() * 1000 (roughly)
+local now_s = os.time()
+assert(ms >= now_s * 1000, "now_ms should be >= os.time() * 1000")
+
+-- parse should convert date strings to Unix timestamps
+local ts = time.parse("2026-02-09", "%Y-%m-%d")
+assert(type(ts) == "number", "parse should return a number")
+assert(ts > 0, "parse should return a positive number")
+
+-- parse with time component
+local ts2 = time.parse("2026-02-09 12:00:00", "%Y-%m-%d %H:%M:%S")
+assert(ts2 > ts, "timestamp with noon should be greater than midnight")
+
+-- parse with known value: 1970-01-01 should be 0
+local epoch = time.parse("1970-01-01 00:00:00", "%Y-%m-%d %H:%M:%S")
+assert(epoch == 0, "1970-01-01 00:00:00 should be epoch 0, got " .. tostring(epoch))
+
+return true

--- a/src/fixtures/bindings/time.lua
+++ b/src/fixtures/bindings/time.lua
@@ -9,17 +9,38 @@ assert(ms > 0, "now_ms should return a positive number")
 local now_s = os.time()
 assert(ms >= now_s * 1000, "now_ms should be >= os.time() * 1000")
 
--- parse should convert date strings to Unix timestamps
+-- parse with explicit format (strptime)
 local ts = time.parse("2026-02-09", "%Y-%m-%d")
 assert(type(ts) == "number", "parse should return a number")
 assert(ts > 0, "parse should return a positive number")
 
--- parse with time component
 local ts2 = time.parse("2026-02-09 12:00:00", "%Y-%m-%d %H:%M:%S")
 assert(ts2 > ts, "timestamp with noon should be greater than midnight")
 
--- parse with known value: 1970-01-01 should be 0
 local epoch = time.parse("1970-01-01 00:00:00", "%Y-%m-%d %H:%M:%S")
 assert(epoch == 0, "1970-01-01 00:00:00 should be epoch 0, got " .. tostring(epoch))
+
+-- auto-detect: RFC 3339 / ISO 8601
+local rfc3339 = time.parse("2026-02-09T12:00:00Z")
+assert(rfc3339 == ts2, "RFC 3339 should match explicit parse, got " .. tostring(rfc3339))
+
+local rfc3339_offset = time.parse("2026-02-09T20:00:00+08:00")
+assert(rfc3339_offset == ts2, "RFC 3339 with +08:00 should match UTC noon, got " .. tostring(rfc3339_offset))
+
+-- auto-detect: ISO 8601 date only
+local iso_date = time.parse("2026-02-09")
+assert(iso_date == ts, "ISO date should match explicit parse, got " .. tostring(iso_date))
+
+-- auto-detect: ISO 8601 datetime without offset (treated as UTC)
+local iso_dt = time.parse("2026-02-09 12:00:00")
+assert(iso_dt == ts2, "ISO datetime should match explicit parse, got " .. tostring(iso_dt))
+
+-- auto-detect: RFC 2822 / 1123
+local rfc2822 = time.parse("Mon, 09 Feb 2026 12:00:00 +0000")
+assert(rfc2822 == ts2, "RFC 2822 should match UTC noon, got " .. tostring(rfc2822))
+
+-- auto-detect: asctime
+local asctime = time.parse("Mon Feb  9 12:00:00 2026")
+assert(asctime == ts2, "asctime should match UTC noon, got " .. tostring(asctime))
 
 return true

--- a/src/fixtures/bindings/time.lua
+++ b/src/fixtures/bindings/time.lua
@@ -43,4 +43,12 @@ assert(rfc2822 == ts2, "RFC 2822 should match UTC noon, got " .. tostring(rfc282
 local asctime = time.parse("Mon Feb  9 12:00:00 2026")
 assert(asctime == ts2, "asctime should match UTC noon, got " .. tostring(asctime))
 
+-- error: auto-detect with invalid input
+local ok, err = pcall(time.parse, "not-a-date")
+assert(not ok, "parse should fail on invalid input")
+
+-- error: explicit format with invalid input
+local ok2, err2 = pcall(time.parse, "not-a-date", "%Y-%m-%d")
+assert(not ok2, "parse should fail with mismatched format")
+
 return true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,6 +252,7 @@ impl Runner {
             vm.register_module("@lmb/json", bindings::json::JsonBinding {})?;
             vm.register_module("@lmb/json-path", bindings::json_path::JsonPathBinding {})?;
             vm.register_module("@lmb/logging", bindings::logging::LoggingBinding {})?;
+            vm.register_module("@lmb/time", bindings::time::TimeBinding {})?;
             vm.register_module("@lmb/toml", bindings::toml::TomlBinding {})?;
             vm.register_module("@lmb/yaml", bindings::yaml::YamlBinding {})?;
         }


### PR DESCRIPTION
## Summary

- Add `@lmb/time` module providing `now_ms()` and `parse()` functions
- `now_ms()` returns millisecond-precision Unix timestamp via `std::time::SystemTime`
- `parse(input [, format])` converts date strings to Unix timestamps:
  - With `format`: uses POSIX strptime format specifiers
  - Without `format`: auto-detects from supported formats in order:
    1. RFC 3339 / RFC 9557 / ISO 8601 (via jiff built-in parser)
    2. RFC 2822 / 5322 / 1123
    3. asctime
- When parsed input lacks timezone/offset info, defaults to UTC

Closes #136

## Test plan

- [x] Unit test covering `now_ms()` and `parse()` with explicit format
- [x] Unit test covering auto-detect for RFC 3339, ISO 8601 date/datetime, RFC 2822, and asctime
- [x] Guided tour section with runnable example
- [x] All existing tests pass (237 unit + 19 CLI + 1 guided tour)

🤖 Generated with [Claude Code](https://claude.com/claude-code)