### PR TITLE
feat: add PostgreSQL store backend

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        toolchain: [1.88.0, 1.94.0]
+        toolchain: [1.93.0, 1.94.0]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,6 +57,9 @@ jobs:
           key: ${{ runner.os }}-cargo-check-${{ matrix.toolchain }}-${{ hashFiles('**/Cargo.lock') }}
       - name: Check code linting
         run: cargo clippy
+      - name: Check code linting (all features)
+        if: runner.os == 'Linux'
+        run: cargo clippy --all-features
   bench:
     needs: [lint, check]
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,6 +98,20 @@ jobs:
   coverage:
     needs: [lint, check]
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:17-alpine
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_USER: lmb
+          POSTGRES_PASSWORD: lmb
+          POSTGRES_DB: lmb
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
@@ -120,6 +134,8 @@ jobs:
         with:
           tool: cargo-llvm-cov@0.6.14,cargo-nextest@0.9.87
       - name: Run tests with coverage
+        env:
+          DATABASE_URL: postgres://lmb:lmb@localhost:5432/lmb
         run: cargo llvm-cov nextest --all-features --workspace --ignore-filename-regex main.rs --lcov --output-path lcov.info
       - name: Upload coverage report
         uses: codecov/codecov-action@v5.5.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,6 +145,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -435,6 +446,12 @@ name = "bytecount"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -1113,6 +1130,12 @@ dependencies = [
 
 [[package]]
 name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
@@ -1332,7 +1355,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -1892,6 +1915,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
+name = "libredox"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1961,6 +1993,7 @@ dependencies = [
  "mockito",
  "no_color",
  "parking_lot",
+ "postgres",
  "pulldown-cmark",
  "reqwest",
  "rmp-serde",
@@ -2146,7 +2179,7 @@ checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
 
@@ -2331,6 +2364,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2471,6 +2522,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2542,6 +2612,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "postgres"
+version = "0.19.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c48ece1c6cda0db61b058c1721378da76855140e9214339fa1317decacb176"
+dependencies = [
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "futures-util",
+ "log",
+ "tokio",
+ "tokio-postgres",
+]
+
+[[package]]
+name = "postgres-protocol"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee9dd5fe15055d2b6806f4736aa0c9637217074e224bbec46d4041b91bb9491"
+dependencies = [
+ "base64",
+ "byteorder",
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "hmac",
+ "md-5",
+ "memchr",
+ "rand 0.9.2",
+ "sha2",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b858f82211e84682fecd373f68e1ceae642d8d751a1ebd13f33de6257b3e20"
+dependencies = [
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "postgres-protocol",
 ]
 
 [[package]]
@@ -3028,7 +3141,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1c93dd1c9683b438c392c492109cb702b8090b2bfc8fed6f6e4eb4523f17af3"
 dependencies = [
  "bitflags",
- "fallible-iterator",
+ "fallible-iterator 0.3.0",
  "fallible-streaming-iterator",
  "hashlink",
  "libsqlite3-sys",
@@ -3428,6 +3541,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3535,6 +3654,17 @@ name = "string-offsets"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a651d1095b5b70f1a88e10dbcf58625e30140112b0f9f55f334e0f84ec2e3176"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
 
 [[package]]
 name = "strsim"
@@ -3864,6 +3994,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-postgres"
+version = "0.7.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcea47c8f71744367793f16c2db1f11cb859d28f436bdb4ca9193eb1f787ee42"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "parking_lot",
+ "percent-encoding",
+ "phf",
+ "pin-project-lite",
+ "postgres-protocol",
+ "postgres-types",
+ "rand 0.9.2",
+ "socket2",
+ "tokio",
+ "tokio-util",
+ "whoami",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4100,6 +4256,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4110,6 +4272,21 @@ name = "unicode-linebreak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -4246,6 +4423,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4261,6 +4447,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasite"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
+dependencies = [
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
@@ -4392,6 +4587,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "whoami"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6a5b12f9df4f978d2cfdb1bd3bac52433f44393342d7ee9c25f5a1c14c0f45d"
+dependencies = [
+ "libc",
+ "libredox",
+ "objc2-system-configuration",
+ "wasite",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "lmb"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.88.0"
+rust-version = "1.93.0"
 license = "MIT"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,10 @@ edition = "2024"
 rust-version = "1.88.0"
 license = "MIT"
 
+[features]
+default = []
+postgres = ["dep:postgres"]
+
 [dependencies]
 aes = "0.8.4"
 anyhow = "1.0.101"
@@ -39,6 +43,7 @@ mlua = { version = "0.11.1", features = [
 ] }
 no_color = "0.2.0"
 parking_lot = "0.12.4"
+postgres = { version = "0.19", optional = true }
 pulldown-cmark = "0.13.1"
 reqwest = { version = "0.12.22", default-features = false, features = [
   "charset",
@@ -108,7 +113,7 @@ harness = false
 future_incompatible = { level = "warn", priority = -1 }
 nonstandard_style = { level = "warn", priority = -1 }
 rust_2018_idioms = { level = "warn", priority = -1 }
-unexpected_cfgs = "deny"
+unexpected_cfgs = { level = "deny", check-cfg = ['cfg(feature, values("postgres"))'] }
 unsafe_code = "deny"
 
 [lints.clippy]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,14 @@
+services:
+  postgres:
+    image: postgres:17-alpine
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: lmb
+      POSTGRES_PASSWORD: lmb
+      POSTGRES_DB: lmb
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+volumes:
+  pgdata:

--- a/src/bindings/time.rs
+++ b/src/bindings/time.rs
@@ -79,10 +79,10 @@ fn parse_auto(input: &str) -> Result<i64, String> {
 
     // 2-3. Try strptime with known formats
     for fmt in AUTO_FORMATS {
-        if let Ok(tm) = jiff::fmt::strtime::parse(fmt, input) {
-            if let Some(ts) = broken_down_to_timestamp(&tm) {
-                return Ok(ts);
-            }
+        if let Ok(tm) = jiff::fmt::strtime::parse(fmt, input)
+            && let Some(ts) = broken_down_to_timestamp(&tm)
+        {
+            return Ok(ts);
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,6 +117,10 @@ struct Opts {
     /// Path to `SQLite` file for persistent key-value storage
     #[clap(long, value_parser, group = "store_group", env = "STORE_PATH")]
     store_path: Option<PathBuf>,
+    /// `PostgreSQL` connection URL for persistent key-value storage
+    #[cfg(feature = "postgres")]
+    #[clap(long, group = "store_group", env = "STORE_URL")]
+    store_url: Option<String>,
     /// Script execution timeout (e.g., 30s, 1m). Default: 30s, use 0 for unlimited
     #[clap(long, env = "TIMEOUT")]
     timeout: Option<jiff::Span>,
@@ -192,8 +196,14 @@ fn parse_timeout(span: Option<jiff::Span>) -> anyhow::Result<Option<Duration>> {
 
 pub(crate) fn open_store_connection(
     store_path: Option<PathBuf>,
+    #[cfg(feature = "postgres")] store_url: Option<String>,
     no_store: bool,
 ) -> anyhow::Result<Option<LmbStore>> {
+    #[cfg(feature = "postgres")]
+    if let Some(url) = store_url {
+        let backend = lmb::store::PostgresBackend::connect(&url)?;
+        return Ok(Some(Arc::new(backend)));
+    }
     match (store_path, no_store) {
         (None, false) => {
             let backend = SqliteBackend::new(Connection::open_in_memory()?);
@@ -349,9 +359,19 @@ async fn try_main() -> anyhow::Result<()> {
             debug!("Using timeout: {timeout:?}");
 
             if opts.store_path.is_none() && !opts.no_store {
+                #[cfg(feature = "postgres")]
+                if opts.store_url.is_none() {
+                    warn!("No store path specified, using in-memory store");
+                }
+                #[cfg(not(feature = "postgres"))]
                 warn!("No store path specified, using in-memory store");
             }
-            let conn = open_store_connection(opts.store_path, opts.no_store)?;
+            let conn = open_store_connection(
+                opts.store_path,
+                #[cfg(feature = "postgres")]
+                opts.store_url,
+                opts.no_store,
+            )?;
 
             let runner = if let Some(source) = &source {
                 debug!("Evaluating Lua code from stdin or a string input");
@@ -450,20 +470,20 @@ async fn try_main() -> anyhow::Result<()> {
                 );
             }
 
-            let app_state = Arc::new(
-                AppState::builder()
-                    .source(source)
-                    .maybe_http_timeout(http_timeout)
-                    .max_body_size(max_body_size)
-                    .name(name)
-                    .no_store(opts.no_store)
-                    .permissions(permissions)
-                    .maybe_pool_size(pool_size)
-                    .maybe_state(state)
-                    .maybe_store_path(opts.store_path)
-                    .maybe_timeout(timeout)
-                    .build(),
-            );
+            let app_state_builder = AppState::builder()
+                .source(source)
+                .maybe_http_timeout(http_timeout)
+                .max_body_size(max_body_size)
+                .name(name)
+                .no_store(opts.no_store)
+                .permissions(permissions)
+                .maybe_pool_size(pool_size)
+                .maybe_state(state)
+                .maybe_store_path(opts.store_path)
+                .maybe_timeout(timeout);
+            #[cfg(feature = "postgres")]
+            let app_state_builder = app_state_builder.maybe_store_url(opts.store_url);
+            let app_state = Arc::new(app_state_builder.build());
 
             let pool = if pool_size.is_some() {
                 Some(Arc::new(serve::create_pool(&app_state)?))
@@ -500,6 +520,8 @@ struct AppState {
     pool_size: Option<usize>,
     state: Option<Value>,
     store_path: Option<PathBuf>,
+    #[cfg(feature = "postgres")]
+    store_url: Option<String>,
     timeout: Option<Duration>,
 }
 

--- a/src/migrations/0001-initial.pg.sql
+++ b/src/migrations/0001-initial.pg.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS store (
+    id BIGSERIAL PRIMARY KEY,
+    key TEXT NOT NULL UNIQUE,
+    value BYTEA NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_store_key ON store (key);

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -43,8 +43,13 @@ where
     type Error = LmbError;
 
     async fn create(&self) -> Result<Self::Type, Self::Error> {
+        let store = self
+            .store
+            .as_ref()
+            .map(|s| s.fork())
+            .transpose()?;
         Runner::from_shared_reader(self.source.clone(), self.reader.clone())
-            .maybe_store(self.store.clone())
+            .maybe_store(store)
             .call()
     }
 

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -43,11 +43,7 @@ where
     type Error = LmbError;
 
     async fn create(&self) -> Result<Self::Type, Self::Error> {
-        let store = self
-            .store
-            .as_ref()
-            .map(|s| s.fork())
-            .transpose()?;
+        let store = self.store.as_ref().map(|s| s.fork()).transpose()?;
         Runner::from_shared_reader(self.source.clone(), self.reader.clone())
             .maybe_store(store)
             .call()

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -24,6 +24,8 @@ pub(crate) fn create_pool(app_state: &AppState) -> anyhow::Result<RunnerPool> {
 
     let store = open_store_connection(
         app_state.store_path.clone(),
+        #[cfg(feature = "postgres")]
+        app_state.store_url.clone(),
         app_state.no_store.unwrap_or(false),
     )?;
 
@@ -103,6 +105,8 @@ async fn try_request_handler(
         let reader = Cursor::new(bytes);
         let conn = open_store_connection(
             app_state.store_path.clone(),
+            #[cfg(feature = "postgres")]
+            app_state.store_url.clone(),
             app_state.no_store.unwrap_or(false),
         )?;
 

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -33,4 +33,10 @@ pub trait StoreBackend: Send + Sync + std::fmt::Debug {
     fn rollback_tx(&self) -> LmbResult<()>;
     /// Runs any pending migrations.
     fn migrate(&self) -> LmbResult<()>;
+    /// Creates an independent backend instance suitable for concurrent use.
+    ///
+    /// For connection-per-thread backends (e.g. PostgreSQL), this opens a new
+    /// connection. For backends with built-in concurrency control (e.g. SQLite),
+    /// this may share the underlying connection.
+    fn fork(&self) -> LmbResult<std::sync::Arc<dyn StoreBackend>>;
 }

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -35,8 +35,8 @@ pub trait StoreBackend: Send + Sync + std::fmt::Debug {
     fn migrate(&self) -> LmbResult<()>;
     /// Creates an independent backend instance suitable for concurrent use.
     ///
-    /// For connection-per-thread backends (e.g. PostgreSQL), this opens a new
-    /// connection. For backends with built-in concurrency control (e.g. SQLite),
+    /// For connection-per-thread backends (e.g. `PostgreSQL`), this opens a new
+    /// connection. For backends with built-in concurrency control (e.g. `SQLite`),
     /// this may share the underlying connection.
     fn fork(&self) -> LmbResult<std::sync::Arc<dyn StoreBackend>>;
 }

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -1,6 +1,11 @@
+/// `PostgreSQL` store backend implementation.
+#[cfg(feature = "postgres")]
+pub mod postgres;
 /// `SQLite` store backend implementation.
 pub mod sqlite;
 
+#[cfg(feature = "postgres")]
+pub use self::postgres::PostgresBackend;
 pub use sqlite::SqliteBackend;
 
 use serde_json::Value;

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -1,0 +1,336 @@
+use std::fmt;
+
+use parking_lot::Mutex;
+use postgres::{Client, NoTls};
+use serde_json::Value;
+use tracing::debug_span;
+
+use crate::{LmbError, LmbResult};
+
+use super::StoreBackend;
+
+static MIGRATIONS: &[&str] = &[include_str!("../migrations/0001-initial.pg.sql")];
+
+static SQL_GET: &str = "SELECT value FROM store WHERE key = $1";
+static SQL_PUT: &str = "INSERT INTO store (key, value) VALUES ($1, $2) ON CONFLICT (key) DO UPDATE SET value = $2, updated_at = NOW()";
+static SQL_DEL: &str = "DELETE FROM store WHERE key = $1";
+static SQL_HAS: &str = "SELECT 1 FROM store WHERE key = $1";
+static SQL_KEYS: &str = "SELECT key FROM store WHERE key LIKE $1";
+static SQL_KEYS_ALL: &str = "SELECT key FROM store";
+
+/// PostgreSQL-backed implementation of [`StoreBackend`].
+pub struct PostgresBackend {
+    client: Mutex<Client>,
+}
+
+impl fmt::Debug for PostgresBackend {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PostgresBackend").finish_non_exhaustive()
+    }
+}
+
+impl PostgresBackend {
+    /// Creates a new `PostgresBackend` wrapping the given client.
+    pub fn new(client: Client) -> Self {
+        Self {
+            client: Mutex::new(client),
+        }
+    }
+
+    /// Creates a new `PostgresBackend` by connecting to the given URL.
+    pub fn connect(url: &str) -> LmbResult<Self> {
+        let client = Client::connect(url, NoTls).map_err(|e| LmbError::Store(Box::new(e)))?;
+        Ok(Self::new(client))
+    }
+}
+
+impl StoreBackend for PostgresBackend {
+    fn get(&self, key: &str) -> LmbResult<Option<Value>> {
+        let mut client = self.client.lock();
+        let rows = client
+            .query(SQL_GET, &[&key])
+            .map_err(|e| LmbError::Store(Box::new(e)))?;
+        if let Some(row) = rows.first() {
+            let value: Vec<u8> = row.get(0);
+            let value: Value = rmp_serde::from_slice(&value)?;
+            Ok(Some(value))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn put(&self, key: &str, value: &Value) -> LmbResult<()> {
+        let serialized = rmp_serde::to_vec(value)?;
+        let mut client = self.client.lock();
+        client
+            .execute(SQL_PUT, &[&key, &serialized])
+            .map_err(|e| LmbError::Store(Box::new(e)))?;
+        Ok(())
+    }
+
+    fn del(&self, key: &str) -> LmbResult<bool> {
+        let mut client = self.client.lock();
+        let affected = client
+            .execute(SQL_DEL, &[&key])
+            .map_err(|e| LmbError::Store(Box::new(e)))?;
+        Ok(affected > 0)
+    }
+
+    fn has(&self, key: &str) -> LmbResult<bool> {
+        let mut client = self.client.lock();
+        let rows = client
+            .query(SQL_HAS, &[&key])
+            .map_err(|e| LmbError::Store(Box::new(e)))?;
+        Ok(!rows.is_empty())
+    }
+
+    fn keys(&self, pattern: Option<&str>) -> LmbResult<Vec<String>> {
+        let mut client = self.client.lock();
+        let rows = if let Some(pat) = pattern {
+            client
+                .query(SQL_KEYS, &[&pat])
+                .map_err(|e| LmbError::Store(Box::new(e)))?
+        } else {
+            client
+                .query(SQL_KEYS_ALL, &[])
+                .map_err(|e| LmbError::Store(Box::new(e)))?
+        };
+        Ok(rows.iter().map(|row| row.get(0)).collect())
+    }
+
+    fn begin_tx(&self) -> LmbResult<()> {
+        let mut client = self.client.lock();
+        client
+            .batch_execute("BEGIN")
+            .map_err(|e| LmbError::Store(Box::new(e)))?;
+        Ok(())
+    }
+
+    fn commit_tx(&self) -> LmbResult<()> {
+        let mut client = self.client.lock();
+        client
+            .batch_execute("COMMIT")
+            .map_err(|e| LmbError::Store(Box::new(e)))?;
+        Ok(())
+    }
+
+    fn rollback_tx(&self) -> LmbResult<()> {
+        let mut client = self.client.lock();
+        client
+            .batch_execute("ROLLBACK")
+            .map_err(|e| LmbError::Store(Box::new(e)))?;
+        Ok(())
+    }
+
+    fn migrate(&self) -> LmbResult<()> {
+        let mut client = self.client.lock();
+
+        // Use advisory lock to prevent concurrent migration runs
+        client
+            .batch_execute("SELECT pg_advisory_lock(42)")
+            .map_err(|e| LmbError::Store(Box::new(e)))?;
+
+        // Create migrations tracking table
+        client
+            .batch_execute(
+                "CREATE TABLE IF NOT EXISTS lmb_migrations (version INTEGER PRIMARY KEY)",
+            )
+            .map_err(|e| LmbError::Store(Box::new(e)))?;
+
+        let current_version: i32 = client
+            .query_one("SELECT COALESCE(MAX(version), 0) FROM lmb_migrations", &[])
+            .map_err(|e| LmbError::Store(Box::new(e)))?
+            .get(0);
+        let migrations_to_run = MIGRATIONS.len() as i32;
+
+        if current_version < migrations_to_run {
+            let span =
+                debug_span!("run_migrations", current_version, total = migrations_to_run).entered();
+            for (idx, migration) in MIGRATIONS.iter().enumerate() {
+                let version = idx as i32 + 1;
+                if version > current_version {
+                    let _ =
+                        debug_span!(parent: &span, "run_migration", version, migration).entered();
+                    client
+                        .batch_execute(migration)
+                        .map_err(|e| LmbError::Store(Box::new(e)))?;
+                    client
+                        .execute(
+                            "INSERT INTO lmb_migrations (version) VALUES ($1) ON CONFLICT DO NOTHING",
+                            &[&version],
+                        )
+                        .map_err(|e| LmbError::Store(Box::new(e)))?;
+                }
+            }
+        }
+
+        // Release advisory lock
+        client
+            .batch_execute("SELECT pg_advisory_unlock(42)")
+            .map_err(|e| LmbError::Store(Box::new(e)))?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex as StdMutex;
+
+    use serde_json::json;
+
+    use super::*;
+
+    // Serialize all PG tests since they share a single database
+    static TEST_LOCK: StdMutex<()> = StdMutex::new(());
+
+    fn create_test_backend() -> std::sync::MutexGuard<'static, ()> {
+        let guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let url = std::env::var("DATABASE_URL")
+            .unwrap_or_else(|_| "postgres://lmb:lmb@localhost:5432/lmb".to_string());
+        let backend = PostgresBackend::connect(&url).expect("Failed to connect to PostgreSQL");
+        backend.migrate().expect("Failed to run migrations");
+        backend
+            .client
+            .lock()
+            .batch_execute("DELETE FROM store")
+            .expect("Failed to clean up store table");
+        drop(backend);
+        guard
+    }
+
+    fn connect() -> PostgresBackend {
+        let url = std::env::var("DATABASE_URL")
+            .unwrap_or_else(|_| "postgres://lmb:lmb@localhost:5432/lmb".to_string());
+        PostgresBackend::connect(&url).expect("Failed to connect to PostgreSQL")
+    }
+
+    #[test]
+    fn test_get_nonexistent_key() {
+        let _guard = create_test_backend();
+        let backend = connect();
+        let result = backend.get("nonexistent").unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_put_and_get() {
+        let _guard = create_test_backend();
+        let backend = connect();
+        let value = json!({"hello": "world"});
+        backend.put("key1", &value).unwrap();
+        let result = backend.get("key1").unwrap();
+        assert_eq!(Some(value), result);
+    }
+
+    #[test]
+    fn test_overwrite_value() {
+        let _guard = create_test_backend();
+        let backend = connect();
+        let value1 = json!(1);
+        let value2 = json!(2);
+        backend.put("counter", &value1).unwrap();
+        assert_eq!(Some(value1), backend.get("counter").unwrap());
+        backend.put("counter", &value2).unwrap();
+        assert_eq!(Some(value2), backend.get("counter").unwrap());
+    }
+
+    #[test]
+    fn test_del() {
+        let _guard = create_test_backend();
+        let backend = connect();
+        backend.put("key1", &json!("val")).unwrap();
+        assert!(backend.del("key1").unwrap());
+        assert!(!backend.del("key1").unwrap());
+        assert!(backend.get("key1").unwrap().is_none());
+    }
+
+    #[test]
+    fn test_has() {
+        let _guard = create_test_backend();
+        let backend = connect();
+        assert!(!backend.has("key1").unwrap());
+        backend.put("key1", &json!("val")).unwrap();
+        assert!(backend.has("key1").unwrap());
+    }
+
+    #[test]
+    fn test_keys() {
+        let _guard = create_test_backend();
+        let backend = connect();
+        backend.put("user:1", &json!("a")).unwrap();
+        backend.put("user:2", &json!("b")).unwrap();
+        backend.put("item:1", &json!("c")).unwrap();
+
+        let mut all = backend.keys(None).unwrap();
+        all.sort();
+        assert_eq!(vec!["item:1", "user:1", "user:2"], all);
+
+        let mut users = backend.keys(Some("user:%")).unwrap();
+        users.sort();
+        assert_eq!(vec!["user:1", "user:2"], users);
+    }
+
+    #[test]
+    fn test_transaction_commit() {
+        let _guard = create_test_backend();
+        let backend = connect();
+        backend.begin_tx().unwrap();
+        backend.put("tx_key", &json!("tx_val")).unwrap();
+        backend.commit_tx().unwrap();
+        assert_eq!(Some(json!("tx_val")), backend.get("tx_key").unwrap());
+    }
+
+    #[test]
+    fn test_transaction_rollback() {
+        let _guard = create_test_backend();
+        let backend = connect();
+        backend.put("existing", &json!("before")).unwrap();
+        backend.begin_tx().unwrap();
+        backend.put("existing", &json!("during")).unwrap();
+        backend.rollback_tx().unwrap();
+        assert_eq!(Some(json!("before")), backend.get("existing").unwrap());
+    }
+
+    #[test]
+    fn test_complex_json_value() {
+        let _guard = create_test_backend();
+        let backend = connect();
+        let value = json!({
+            "string": "hello",
+            "number": 42,
+            "float": 1.23,
+            "boolean": true,
+            "null": null,
+            "array": [1, 2, 3],
+            "nested": {
+                "a": {"b": {"c": "deep"}}
+            }
+        });
+        backend.put("complex", &value).unwrap();
+        assert_eq!(Some(value), backend.get("complex").unwrap());
+    }
+
+    #[test]
+    fn test_unicode_key_and_value() {
+        let _guard = create_test_backend();
+        let backend = connect();
+        let key = "你好世界";
+        let value = json!({
+            "greeting": "こんにちは",
+            "emoji": "🎉🚀",
+            "arabic": "مرحبا"
+        });
+        backend.put(key, &value).unwrap();
+        assert_eq!(Some(value), backend.get(key).unwrap());
+    }
+
+    #[test]
+    fn test_migrate_idempotent() {
+        let _guard = create_test_backend();
+        let backend = connect();
+        backend.migrate().unwrap();
+        backend.put("key", &json!("val")).unwrap();
+        assert_eq!(Some(json!("val")), backend.get("key").unwrap());
+    }
+}

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -197,127 +197,148 @@ impl StoreBackend for PostgresBackend {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Mutex as StdMutex;
-
     use serde_json::json;
 
     use super::*;
 
-    // Serialize all PG tests since they share a single database
-    static TEST_LOCK: StdMutex<()> = StdMutex::new(());
-
-    fn create_test_backend() -> std::sync::MutexGuard<'static, ()> {
-        let guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        let url = std::env::var("DATABASE_URL")
-            .unwrap_or_else(|_| "postgres://lmb:lmb@localhost:5432/lmb".to_string());
-        let backend = PostgresBackend::connect(&url).expect("Failed to connect to PostgreSQL");
-        backend.migrate().expect("Failed to run migrations");
-        backend
-            .client
-            .lock()
-            .batch_execute("DELETE FROM store")
-            .expect("Failed to clean up store table");
-        drop(backend);
-        guard
+    /// Guard that holds a PG advisory lock for the lifetime of a test,
+    /// ensuring tests don't interfere with each other even when run in
+    /// separate processes (e.g. nextest).
+    struct PgTestGuard {
+        backend: PostgresBackend,
     }
 
-    fn connect() -> PostgresBackend {
-        let url = std::env::var("DATABASE_URL")
-            .unwrap_or_else(|_| "postgres://lmb:lmb@localhost:5432/lmb".to_string());
-        PostgresBackend::connect(&url).expect("Failed to connect to PostgreSQL")
+    impl PgTestGuard {
+        fn new() -> Self {
+            let url = std::env::var("DATABASE_URL")
+                .unwrap_or_else(|_| "postgres://lmb:lmb@localhost:5432/lmb".to_string());
+            let backend = PostgresBackend::connect(&url).expect("Failed to connect to PostgreSQL");
+            backend.migrate().expect("Failed to run migrations");
+            // Acquire a cross-process advisory lock to serialize tests
+            backend
+                .client
+                .lock()
+                .batch_execute("SELECT pg_advisory_lock(hashtext('lmb_test'))")
+                .expect("Failed to acquire test advisory lock");
+            backend
+                .client
+                .lock()
+                .batch_execute("DELETE FROM store")
+                .expect("Failed to clean up store table");
+            Self { backend }
+        }
+
+        fn backend(&self) -> &PostgresBackend {
+            &self.backend
+        }
+    }
+
+    impl Drop for PgTestGuard {
+        fn drop(&mut self) {
+            let _ = self
+                .client
+                .lock()
+                .batch_execute("SELECT pg_advisory_unlock(hashtext('lmb_test'))");
+        }
+    }
+
+    // Deref to PostgresBackend so the guard's own connection can be
+    // forwarded through the `client` field when needed.
+    impl std::ops::Deref for PgTestGuard {
+        type Target = PostgresBackend;
+        fn deref(&self) -> &Self::Target {
+            &self.backend
+        }
     }
 
     #[test]
     fn test_get_nonexistent_key() {
-        let _guard = create_test_backend();
-        let backend = connect();
-        let result = backend.get("nonexistent").unwrap();
+        let guard = PgTestGuard::new();
+        let result = guard.backend().get("nonexistent").unwrap();
         assert!(result.is_none());
     }
 
     #[test]
     fn test_put_and_get() {
-        let _guard = create_test_backend();
-        let backend = connect();
+        let guard = PgTestGuard::new();
         let value = json!({"hello": "world"});
-        backend.put("key1", &value).unwrap();
-        let result = backend.get("key1").unwrap();
+        guard.backend().put("key1", &value).unwrap();
+        let result = guard.backend().get("key1").unwrap();
         assert_eq!(Some(value), result);
     }
 
     #[test]
     fn test_overwrite_value() {
-        let _guard = create_test_backend();
-        let backend = connect();
+        let guard = PgTestGuard::new();
         let value1 = json!(1);
         let value2 = json!(2);
-        backend.put("counter", &value1).unwrap();
-        assert_eq!(Some(value1), backend.get("counter").unwrap());
-        backend.put("counter", &value2).unwrap();
-        assert_eq!(Some(value2), backend.get("counter").unwrap());
+        guard.backend().put("counter", &value1).unwrap();
+        assert_eq!(Some(value1), guard.backend().get("counter").unwrap());
+        guard.backend().put("counter", &value2).unwrap();
+        assert_eq!(Some(value2), guard.backend().get("counter").unwrap());
     }
 
     #[test]
     fn test_del() {
-        let _guard = create_test_backend();
-        let backend = connect();
-        backend.put("key1", &json!("val")).unwrap();
-        assert!(backend.del("key1").unwrap());
-        assert!(!backend.del("key1").unwrap());
-        assert!(backend.get("key1").unwrap().is_none());
+        let guard = PgTestGuard::new();
+        guard.backend().put("key1", &json!("val")).unwrap();
+        assert!(guard.backend().del("key1").unwrap());
+        assert!(!guard.backend().del("key1").unwrap());
+        assert!(guard.backend().get("key1").unwrap().is_none());
     }
 
     #[test]
     fn test_has() {
-        let _guard = create_test_backend();
-        let backend = connect();
-        assert!(!backend.has("key1").unwrap());
-        backend.put("key1", &json!("val")).unwrap();
-        assert!(backend.has("key1").unwrap());
+        let guard = PgTestGuard::new();
+        assert!(!guard.backend().has("key1").unwrap());
+        guard.backend().put("key1", &json!("val")).unwrap();
+        assert!(guard.backend().has("key1").unwrap());
     }
 
     #[test]
     fn test_keys() {
-        let _guard = create_test_backend();
-        let backend = connect();
-        backend.put("user:1", &json!("a")).unwrap();
-        backend.put("user:2", &json!("b")).unwrap();
-        backend.put("item:1", &json!("c")).unwrap();
+        let guard = PgTestGuard::new();
+        guard.backend().put("user:1", &json!("a")).unwrap();
+        guard.backend().put("user:2", &json!("b")).unwrap();
+        guard.backend().put("item:1", &json!("c")).unwrap();
 
-        let mut all = backend.keys(None).unwrap();
+        let mut all = guard.backend().keys(None).unwrap();
         all.sort();
         assert_eq!(vec!["item:1", "user:1", "user:2"], all);
 
-        let mut users = backend.keys(Some("user:%")).unwrap();
+        let mut users = guard.backend().keys(Some("user:%")).unwrap();
         users.sort();
         assert_eq!(vec!["user:1", "user:2"], users);
     }
 
     #[test]
     fn test_transaction_commit() {
-        let _guard = create_test_backend();
-        let backend = connect();
-        backend.begin_tx().unwrap();
-        backend.put("tx_key", &json!("tx_val")).unwrap();
-        backend.commit_tx().unwrap();
-        assert_eq!(Some(json!("tx_val")), backend.get("tx_key").unwrap());
+        let guard = PgTestGuard::new();
+        guard.backend().begin_tx().unwrap();
+        guard.backend().put("tx_key", &json!("tx_val")).unwrap();
+        guard.backend().commit_tx().unwrap();
+        assert_eq!(
+            Some(json!("tx_val")),
+            guard.backend().get("tx_key").unwrap()
+        );
     }
 
     #[test]
     fn test_transaction_rollback() {
-        let _guard = create_test_backend();
-        let backend = connect();
-        backend.put("existing", &json!("before")).unwrap();
-        backend.begin_tx().unwrap();
-        backend.put("existing", &json!("during")).unwrap();
-        backend.rollback_tx().unwrap();
-        assert_eq!(Some(json!("before")), backend.get("existing").unwrap());
+        let guard = PgTestGuard::new();
+        guard.backend().put("existing", &json!("before")).unwrap();
+        guard.backend().begin_tx().unwrap();
+        guard.backend().put("existing", &json!("during")).unwrap();
+        guard.backend().rollback_tx().unwrap();
+        assert_eq!(
+            Some(json!("before")),
+            guard.backend().get("existing").unwrap()
+        );
     }
 
     #[test]
     fn test_complex_json_value() {
-        let _guard = create_test_backend();
-        let backend = connect();
+        let guard = PgTestGuard::new();
         let value = json!({
             "string": "hello",
             "number": 42,
@@ -329,30 +350,28 @@ mod tests {
                 "a": {"b": {"c": "deep"}}
             }
         });
-        backend.put("complex", &value).unwrap();
-        assert_eq!(Some(value), backend.get("complex").unwrap());
+        guard.backend().put("complex", &value).unwrap();
+        assert_eq!(Some(value), guard.backend().get("complex").unwrap());
     }
 
     #[test]
     fn test_unicode_key_and_value() {
-        let _guard = create_test_backend();
-        let backend = connect();
+        let guard = PgTestGuard::new();
         let key = "你好世界";
         let value = json!({
             "greeting": "こんにちは",
             "emoji": "🎉🚀",
             "arabic": "مرحبا"
         });
-        backend.put(key, &value).unwrap();
-        assert_eq!(Some(value), backend.get(key).unwrap());
+        guard.backend().put(key, &value).unwrap();
+        assert_eq!(Some(value), guard.backend().get(key).unwrap());
     }
 
     #[test]
     fn test_migrate_idempotent() {
-        let _guard = create_test_backend();
-        let backend = connect();
-        backend.migrate().unwrap();
-        backend.put("key", &json!("val")).unwrap();
-        assert_eq!(Some(json!("val")), backend.get("key").unwrap());
+        let guard = PgTestGuard::new();
+        guard.backend().migrate().unwrap();
+        guard.backend().put("key", &json!("val")).unwrap();
+        assert_eq!(Some(json!("val")), guard.backend().get("key").unwrap());
     }
 }

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -172,7 +172,8 @@ impl StoreBackend for PostgresBackend {
             if result.is_err() {
                 let _ = client.batch_execute("ROLLBACK");
                 // Release advisory lock before returning error
-                let _ = client.batch_execute("SELECT pg_advisory_unlock(hashtext('lmb_migration'))");
+                let _ =
+                    client.batch_execute("SELECT pg_advisory_unlock(hashtext('lmb_migration'))");
                 return result;
             }
 

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -124,7 +124,7 @@ impl StoreBackend for PostgresBackend {
 
         // Use advisory lock to prevent concurrent migration runs
         client
-            .batch_execute("SELECT pg_advisory_lock(42)")
+            .batch_execute("SELECT pg_advisory_lock(hashtext('lmb_migration'))")
             .map_err(|e| LmbError::Store(Box::new(e)))?;
 
         // Create migrations tracking table
@@ -143,27 +143,47 @@ impl StoreBackend for PostgresBackend {
         if current_version < migrations_to_run {
             let span =
                 debug_span!("run_migrations", current_version, total = migrations_to_run).entered();
-            for (idx, migration) in MIGRATIONS.iter().enumerate() {
-                let version = idx as i32 + 1;
-                if version > current_version {
-                    let _ =
-                        debug_span!(parent: &span, "run_migration", version, migration).entered();
-                    client
-                        .batch_execute(migration)
-                        .map_err(|e| LmbError::Store(Box::new(e)))?;
-                    client
-                        .execute(
-                            "INSERT INTO lmb_migrations (version) VALUES ($1) ON CONFLICT DO NOTHING",
-                            &[&version],
-                        )
-                        .map_err(|e| LmbError::Store(Box::new(e)))?;
+
+            // Wrap all migrations in a transaction so a partial failure rolls back cleanly
+            client
+                .batch_execute("BEGIN")
+                .map_err(|e| LmbError::Store(Box::new(e)))?;
+
+            let result = (|| -> LmbResult<()> {
+                for (idx, migration) in MIGRATIONS.iter().enumerate() {
+                    let version = idx as i32 + 1;
+                    if version > current_version {
+                        let _ = debug_span!(parent: &span, "run_migration", version, migration)
+                            .entered();
+                        client
+                            .batch_execute(migration)
+                            .map_err(|e| LmbError::Store(Box::new(e)))?;
+                        client
+                            .execute(
+                                "INSERT INTO lmb_migrations (version) VALUES ($1) ON CONFLICT DO NOTHING",
+                                &[&version],
+                            )
+                            .map_err(|e| LmbError::Store(Box::new(e)))?;
+                    }
                 }
+                Ok(())
+            })();
+
+            if result.is_err() {
+                let _ = client.batch_execute("ROLLBACK");
+                // Release advisory lock before returning error
+                let _ = client.batch_execute("SELECT pg_advisory_unlock(hashtext('lmb_migration'))");
+                return result;
             }
+
+            client
+                .batch_execute("COMMIT")
+                .map_err(|e| LmbError::Store(Box::new(e)))?;
         }
 
         // Release advisory lock
         client
-            .batch_execute("SELECT pg_advisory_unlock(42)")
+            .batch_execute("SELECT pg_advisory_unlock(hashtext('lmb_migration'))")
             .map_err(|e| LmbError::Store(Box::new(e)))?;
 
         Ok(())

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -21,6 +21,7 @@ static SQL_KEYS_ALL: &str = "SELECT key FROM store";
 /// PostgreSQL-backed implementation of [`StoreBackend`].
 pub struct PostgresBackend {
     client: Mutex<Client>,
+    url: String,
 }
 
 impl fmt::Debug for PostgresBackend {
@@ -30,17 +31,13 @@ impl fmt::Debug for PostgresBackend {
 }
 
 impl PostgresBackend {
-    /// Creates a new `PostgresBackend` wrapping the given client.
-    pub fn new(client: Client) -> Self {
-        Self {
-            client: Mutex::new(client),
-        }
-    }
-
     /// Creates a new `PostgresBackend` by connecting to the given URL.
     pub fn connect(url: &str) -> LmbResult<Self> {
         let client = Client::connect(url, NoTls).map_err(|e| LmbError::Store(Box::new(e)))?;
-        Ok(Self::new(client))
+        Ok(Self {
+            client: Mutex::new(client),
+            url: url.to_string(),
+        })
     }
 }
 
@@ -170,6 +167,10 @@ impl StoreBackend for PostgresBackend {
             .map_err(|e| LmbError::Store(Box::new(e)))?;
 
         Ok(())
+    }
+
+    fn fork(&self) -> LmbResult<std::sync::Arc<dyn StoreBackend>> {
+        Ok(std::sync::Arc::new(Self::connect(&self.url)?))
     }
 }
 

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -150,6 +150,12 @@ impl StoreBackend for SqliteBackend {
         }
         Ok(())
     }
+
+    fn fork(&self) -> LmbResult<std::sync::Arc<dyn StoreBackend>> {
+        Ok(std::sync::Arc::new(Self {
+            conn: self.conn.clone(),
+        }))
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Add `PostgresBackend` implementing `StoreBackend` trait, gated behind `postgres` feature flag
- Add `--store-url` CLI option for PostgreSQL connection strings (e.g., `--store-url postgres://user:pass@host/db`)
- Add PostgreSQL-specific migration with `BYTEA`/`BIGSERIAL`/`TIMESTAMPTZ` types
- Add `docker-compose.yaml` for local PostgreSQL testing
- Add PostgreSQL service container to CI coverage job for `--all-features` testing

## Test plan

- [x] `cargo test` without `postgres` feature — all existing tests pass
- [x] `cargo test --features postgres --lib store::postgres` — 11 PG tests pass with local PG
- [x] `cargo clippy` / `cargo clippy --features postgres` — no new warnings
- [x] `cargo check --bench bench` — bench compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)