### PR TITLE
feat(fs): add tail -F file following to @lmb/fs

### DIFF
--- a/docs/superpowers/plans/2026-03-17-fs-tail.md
+++ b/docs/superpowers/plans/2026-03-17-fs-tail.md
@@ -1,0 +1,780 @@
+# `fs.tail` Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `tail(path, options?)` method to `@lmb/fs` that follows a file like `tail -F`, yielding new lines via a Lua iterator with automatic rotation detection.
+
+**Architecture:** A `TailState` struct manages file handle, position, and inode tracking. The `tail` method on `FsBinding` returns an async closure (via `create_async_function`) that polls `TailState` for new lines and uses `tokio::time::sleep` between polls to yield the Tokio runtime thread.
+
+**Tech Stack:** Rust, mlua (Luau bindings), tokio, parking_lot, std::os::unix::fs::MetadataExt
+
+**Spec:** `docs/superpowers/specs/2026-03-17-fs-tail-design.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `src/bindings/fs.rs` | Modify | Add `TailState` struct and `tail` method to `FsBinding` |
+| `src/fixtures/bindings/fs/tail-basic.lua` | Create | Lua fixture: tail with `from = "start"`, collect lines, break after reading all |
+| `src/fixtures/bindings/fs/tail-break.lua` | Create | Lua fixture: tail a file, break after N lines |
+| `src/fixtures/bindings/fs/tail-permission-denied.lua` | Create | Lua fixture: tail without permission, assert error |
+| `src/fixtures/bindings/fs/tail-wait-new-lines.lua` | Create | Lua fixture: tail a file, collect lines including ones written after start |
+| `src/fixtures/bindings/fs/tail-rotation.lua` | Create | Lua fixture: tail a file that gets rotated, collect lines from new file |
+| `src/fixtures/bindings/fs/tail-file-not-exists.lua` | Create | Lua fixture: tail a non-existent path, collect lines once it appears |
+
+---
+
+## Chunk 1: TailState and Basic Tail
+
+### Task 1: Add `TailState` struct
+
+**Files:**
+- Modify: `src/bindings/fs.rs`
+
+- [ ] **Step 1: Add imports**
+
+Add to the existing `use` block at the top of `src/bindings/fs.rs`:
+
+```rust
+use std::time::Duration;
+```
+
+Add a `#[cfg(unix)]` import after the existing `use` block:
+
+```rust
+#[cfg(unix)]
+use std::os::unix::fs::MetadataExt;
+```
+
+- [ ] **Step 2: Add `TailState` struct**
+
+Add this struct above the `FsBinding` struct (before `pub(crate) struct FsBinding`):
+
+```rust
+/// Internal state for the `fs.tail()` iterator.
+/// Tracks file position, inode, and handles rotation detection.
+struct TailState {
+    path: PathBuf,
+    reader: Option<BufReader<File>>,
+    inode: Option<u64>,
+    position: u64,
+    poll_interval: u64,
+    from_end: bool,
+    line_buf: String,
+}
+
+impl TailState {
+    fn new(path: String, poll_interval: u64, from_end: bool) -> Self {
+        Self {
+            path: PathBuf::from(path),
+            reader: None,
+            inode: None,
+            position: 0,
+            poll_interval,
+            from_end,
+            line_buf: String::new(),
+        }
+    }
+
+    /// Try to open the file. If `from_end` is true on first open, seek to end.
+    /// Returns true if file is now open, false if file doesn't exist.
+    fn ensure_open(&mut self) -> bool {
+        if self.reader.is_some() {
+            return true;
+        }
+        let file = match File::open(&self.path) {
+            Ok(f) => f,
+            Err(_) => return false,
+        };
+        let metadata = match file.metadata() {
+            Ok(m) => m,
+            Err(_) => return false,
+        };
+        #[cfg(unix)]
+        let inode = Some(metadata.ino());
+        #[cfg(not(unix))]
+        let inode = None;
+
+        let mut reader = BufReader::new(file);
+        if self.from_end && self.inode.is_none() {
+            // First open with from_end: seek to end
+            let end = reader.seek(SeekFrom::End(0)).unwrap_or(0);
+            self.position = end;
+        } else if self.inode.is_some() {
+            // Reopened after rotation: read from beginning
+            self.position = 0;
+        }
+        self.inode = inode;
+        self.reader = Some(reader);
+        true
+    }
+
+    /// Check if the file has been rotated (inode change or size shrink).
+    /// If so, close current reader so `ensure_open` will reopen.
+    fn check_rotation(&mut self) {
+        let metadata = match std::fs::metadata(&self.path) {
+            Ok(m) => m,
+            Err(_) => {
+                // File gone — close reader, enter waiting mode
+                self.reader = None;
+                return;
+            }
+        };
+
+        #[cfg(unix)]
+        if let Some(prev_inode) = self.inode {
+            if metadata.ino() != prev_inode {
+                self.reader = None;
+                return;
+            }
+        }
+
+        if metadata.len() < self.position {
+            // File truncated — close and reopen
+            self.reader = None;
+        }
+    }
+
+    /// Try to read one line. Returns Some(line) with trailing newline stripped,
+    /// or None if at EOF or file not open.
+    fn read_line(&mut self) -> Option<String> {
+        let reader = self.reader.as_mut()?;
+        self.line_buf.clear();
+        match reader.read_line(&mut self.line_buf) {
+            Ok(0) => None, // EOF
+            Ok(n) => {
+                self.position += n as u64;
+                let trimmed = self.line_buf.trim_end_matches('\n').trim_end_matches('\r');
+                Some(trimmed.to_string())
+            }
+            Err(_) => {
+                self.reader = None;
+                None
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `cd /home/nixos/Develop/claude/lmb && cargo check`
+Expected: compiles without errors (TailState is unused but should not error since it's not `pub`)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/bindings/fs.rs
+git commit -m "feat(fs): add TailState struct for tail -F support"
+```
+
+---
+
+### Task 2: Add `tail` method to `FsBinding`
+
+**Files:**
+- Modify: `src/bindings/fs.rs`
+
+- [ ] **Step 1: Add `tail` method**
+
+In the `impl LuaUserData for FsBinding` block, add the `tail` method after the `list` method (before the closing `}` of `add_methods`):
+
+```rust
+        methods.add_method("tail", |vm, this, (path, options): (String, Option<LuaTable>)| {
+            this.check_read_permission(&path)
+                .map_err(LuaError::runtime)?;
+
+            let poll_interval = match &options {
+                Some(t) => t.get::<u64>("poll_interval").unwrap_or(100),
+                None => 100,
+            };
+            let from_end = match &options {
+                Some(t) => {
+                    let from: Option<String> = t.get("from").ok();
+                    !matches!(from.as_deref(), Some("start"))
+                }
+                None => true,
+            };
+
+            let state = Arc::new(Mutex::new(TailState::new(
+                path,
+                poll_interval,
+                from_end,
+            )));
+
+            vm.create_async_function(move |vm, ()| {
+                let state = state.clone();
+                async move {
+                    loop {
+                        let (result, poll_ms) = {
+                            let mut st = state.lock();
+                            // check_rotation BEFORE ensure_open: if rotation detected,
+                            // reader is set to None, then ensure_open reopens the new file.
+                            st.check_rotation();
+                            st.ensure_open();
+                            (st.read_line(), st.poll_interval)
+                        };
+                        // Lock released before await
+
+                        match result {
+                            Some(line) => return vm.create_string(&line).map(LuaValue::String),
+                            None => {
+                                tokio::time::sleep(Duration::from_millis(poll_ms)).await;
+                            }
+                        }
+                    }
+                }
+            })
+        });
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd /home/nixos/Develop/claude/lmb && cargo check`
+Expected: compiles without errors
+
+- [ ] **Step 3: Update module doc comment**
+
+At the top of `src/bindings/fs.rs`, add after the `list(path)` doc line (line ~18):
+
+```rust
+//! - `tail(path, options)` - Follow a file like `tail -F`, returning a line iterator that
+//!   yields new lines as they are appended. Automatically follows file rotations.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/bindings/fs.rs
+git commit -m "feat(fs): add tail method for tail -F file following"
+```
+
+---
+
+### Task 3: Test basic read
+
+**Files:**
+- Create: `src/fixtures/bindings/fs/tail-basic.lua`
+- Modify: `src/bindings/fs.rs` (add test)
+
+- [ ] **Step 1: Create Lua fixture**
+
+```lua
+function tail_basic(ctx)
+  local fs = require("@lmb/fs")
+  local result = {}
+  for line in fs:tail(ctx.state, { from = "start" }) do
+    table.insert(result, line)
+    if #result >= 3 then
+      break
+    end
+  end
+  return result
+end
+
+return tail_basic
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Add to `mod tests` in `src/bindings/fs.rs`:
+
+```rust
+    #[tokio::test]
+    async fn test_tail_basic() {
+        let mut tmp = NamedTempFile::new().expect("create temp file");
+        write!(tmp, "line1\nline2\nline3\n").expect("write temp file");
+        let path = tmp.path().to_string_lossy().to_string();
+        let dir = tmp.path().parent().expect("parent dir").to_path_buf();
+
+        let source = include_str!("../fixtures/bindings/fs/tail-basic.lua");
+        let perm = fs_permissions(
+            ReadPermissions::Some {
+                allowed: [dir].into_iter().collect(),
+                denied: Default::default(),
+            },
+            WritePermissions::Some {
+                allowed: Default::default(),
+                denied: Default::default(),
+            },
+        );
+        let runner = Runner::builder(source, empty())
+            .permissions(perm)
+            .build()
+            .expect("build runner");
+        let state = State::builder().state(json!(path)).build();
+        let result = runner.invoke().state(state).call().await.expect("invoke");
+        assert_eq!(
+            json!(["line1", "line2", "line3"]),
+            result.result.expect("result")
+        );
+    }
+```
+
+- [ ] **Step 3: Run test to verify it passes**
+
+Run: `cd /home/nixos/Develop/claude/lmb && cargo nextest run test_tail_basic`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/fixtures/bindings/fs/tail-basic.lua src/bindings/fs.rs
+git commit -m "test(fs): add basic tail read test"
+```
+
+---
+
+### Task 4: Test break exits cleanly
+
+**Files:**
+- Create: `src/fixtures/bindings/fs/tail-break.lua`
+- Modify: `src/bindings/fs.rs` (add test)
+
+- [ ] **Step 1: Create Lua fixture**
+
+```lua
+function tail_break(ctx)
+  local fs = require("@lmb/fs")
+  local result = {}
+  for line in fs:tail(ctx.state, { from = "start" }) do
+    table.insert(result, line)
+    if #result >= 2 then
+      break
+    end
+  end
+  return result
+end
+
+return tail_break
+```
+
+- [ ] **Step 2: Write the test**
+
+Add to `mod tests`:
+
+```rust
+    #[tokio::test]
+    async fn test_tail_break() {
+        let mut tmp = NamedTempFile::new().expect("create temp file");
+        write!(tmp, "a\nb\nc\nd\ne\n").expect("write temp file");
+        let path = tmp.path().to_string_lossy().to_string();
+        let dir = tmp.path().parent().expect("parent dir").to_path_buf();
+
+        let source = include_str!("../fixtures/bindings/fs/tail-break.lua");
+        let perm = fs_permissions(
+            ReadPermissions::Some {
+                allowed: [dir].into_iter().collect(),
+                denied: Default::default(),
+            },
+            WritePermissions::Some {
+                allowed: Default::default(),
+                denied: Default::default(),
+            },
+        );
+        let runner = Runner::builder(source, empty())
+            .permissions(perm)
+            .build()
+            .expect("build runner");
+        let state = State::builder().state(json!(path)).build();
+        let result = runner.invoke().state(state).call().await.expect("invoke");
+        assert_eq!(json!(["a", "b"]), result.result.expect("result"));
+    }
+```
+
+- [ ] **Step 3: Run test**
+
+Run: `cd /home/nixos/Develop/claude/lmb && cargo nextest run test_tail_break`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/fixtures/bindings/fs/tail-break.lua src/bindings/fs.rs
+git commit -m "test(fs): add tail break test"
+```
+
+---
+
+### Task 5: Test permission denied
+
+**Files:**
+- Create: `src/fixtures/bindings/fs/tail-permission-denied.lua`
+- Modify: `src/bindings/fs.rs` (add test)
+
+- [ ] **Step 1: Create Lua fixture**
+
+```lua
+function tail_permission_denied(ctx)
+  local fs = require("@lmb/fs")
+  local ok, err = pcall(function()
+    for line in fs:tail(ctx.state) do
+      -- should never reach here
+    end
+  end)
+  assert(not ok, "Expected error")
+  assert(string.find(err, "permission denied"), "Expected 'permission denied' in error: " .. tostring(err))
+  return true
+end
+
+return tail_permission_denied
+```
+
+- [ ] **Step 2: Write the test**
+
+Add to `mod tests`:
+
+```rust
+    #[tokio::test]
+    async fn test_tail_permission_denied() {
+        let tmp = NamedTempFile::new().expect("create temp file");
+        let path = tmp.path().to_string_lossy().to_string();
+
+        let source = include_str!("../fixtures/bindings/fs/tail-permission-denied.lua");
+        // No permissions granted
+        let runner = Runner::builder(source, empty())
+            .build()
+            .expect("build runner");
+        let state = State::builder().state(json!(path)).build();
+        let result = runner.invoke().state(state).call().await.expect("invoke");
+        assert_eq!(json!(true), result.result.expect("result"));
+    }
+```
+
+- [ ] **Step 3: Run test**
+
+Run: `cd /home/nixos/Develop/claude/lmb && cargo nextest run test_tail_permission_denied`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/fixtures/bindings/fs/tail-permission-denied.lua src/bindings/fs.rs
+git commit -m "test(fs): add tail permission denied test"
+```
+
+---
+
+## Chunk 2: Advanced Tests (Wait, Rotation, File Not Exists)
+
+### Task 6: Test wait for new lines
+
+**Files:**
+- Create: `src/fixtures/bindings/fs/tail-wait-new-lines.lua`
+- Modify: `src/bindings/fs.rs` (add test)
+
+- [ ] **Step 0: Add missing imports to test module**
+
+Add these to the `use` block inside `mod tests` in `src/bindings/fs.rs`:
+
+```rust
+    use std::fs::{File, OpenOptions};
+    use std::time::Duration;
+```
+
+- [ ] **Step 1: Create Lua fixture**
+
+The fixture reads lines with `from = "start"`. The test writes initial lines, then spawns a thread to append more lines after a delay. The fixture breaks after collecting the expected total.
+
+```lua
+function tail_wait(ctx)
+  local fs = require("@lmb/fs")
+  local result = {}
+  -- ctx.state is { path = "...", expected = N }
+  for line in fs:tail(ctx.state.path, { from = "start", poll_interval = 50 }) do
+    table.insert(result, line)
+    if #result >= ctx.state.expected then
+      break
+    end
+  end
+  return result
+end
+
+return tail_wait
+```
+
+- [ ] **Step 2: Write the test**
+
+Add to `mod tests`:
+
+```rust
+    #[tokio::test]
+    async fn test_tail_wait_new_lines() {
+        let mut tmp = NamedTempFile::new().expect("create temp file");
+        write!(tmp, "first\n").expect("write temp file");
+        let path = tmp.path().to_string_lossy().to_string();
+        let dir = tmp.path().parent().expect("parent dir").to_path_buf();
+
+        let source = include_str!("../fixtures/bindings/fs/tail-wait-new-lines.lua");
+        let perm = fs_permissions(
+            ReadPermissions::Some {
+                allowed: [dir].into_iter().collect(),
+                denied: Default::default(),
+            },
+            WritePermissions::Some {
+                allowed: Default::default(),
+                denied: Default::default(),
+            },
+        );
+        let runner = Runner::builder(source, empty())
+            .permissions(perm)
+            .build()
+            .expect("build runner");
+
+        let write_path = tmp.path().to_path_buf();
+        // Spawn a task to append lines after a short delay
+        let writer = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            let mut f = OpenOptions::new().append(true).open(&write_path).expect("open for append");
+            writeln!(f, "second").expect("write second");
+            writeln!(f, "third").expect("write third");
+        });
+
+        let state = State::builder()
+            .state(json!({"path": path, "expected": 3}))
+            .build();
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(5),
+            runner.invoke().state(state).call(),
+        )
+        .await
+        .expect("should not timeout")
+        .expect("invoke");
+
+        writer.await.expect("writer task");
+        assert_eq!(
+            json!(["first", "second", "third"]),
+            result.result.expect("result")
+        );
+    }
+```
+
+- [ ] **Step 3: Run test**
+
+Run: `cd /home/nixos/Develop/claude/lmb && cargo nextest run test_tail_wait_new_lines`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/fixtures/bindings/fs/tail-wait-new-lines.lua src/bindings/fs.rs
+git commit -m "test(fs): add tail wait for new lines test"
+```
+
+---
+
+### Task 7: Test rotation detection
+
+**Files:**
+- Create: `src/fixtures/bindings/fs/tail-rotation.lua`
+- Modify: `src/bindings/fs.rs` (add test)
+
+- [ ] **Step 1: Create Lua fixture**
+
+```lua
+function tail_rotation(ctx)
+  local fs = require("@lmb/fs")
+  local result = {}
+  for line in fs:tail(ctx.state.path, { from = "start", poll_interval = 50 }) do
+    table.insert(result, line)
+    if #result >= ctx.state.expected then
+      break
+    end
+  end
+  return result
+end
+
+return tail_rotation
+```
+
+- [ ] **Step 2: Write the test**
+
+Add to `mod tests`:
+
+```rust
+    #[tokio::test]
+    async fn test_tail_rotation() {
+        let dir = TempDir::new().expect("create temp dir");
+        let file_path = dir.path().join("test.log");
+        {
+            let mut f = File::create(&file_path).expect("create file");
+            writeln!(f, "old1").expect("write");
+            writeln!(f, "old2").expect("write");
+        }
+        let path_str = file_path.to_string_lossy().to_string();
+        let dir_path = dir.path().to_path_buf();
+
+        let source = include_str!("../fixtures/bindings/fs/tail-rotation.lua");
+        let perm = fs_permissions(
+            ReadPermissions::Some {
+                allowed: [dir_path].into_iter().collect(),
+                denied: Default::default(),
+            },
+            WritePermissions::Some {
+                allowed: Default::default(),
+                denied: Default::default(),
+            },
+        );
+        let runner = Runner::builder(source, empty())
+            .permissions(perm)
+            .build()
+            .expect("build runner");
+
+        let rotate_path = file_path.clone();
+        let rotator = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(300)).await;
+            // Rotate: rename old, create new
+            let rotated = rotate_path.with_extension("log.1");
+            std::fs::rename(&rotate_path, &rotated).expect("rename");
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            let mut f = File::create(&rotate_path).expect("create new file");
+            writeln!(f, "new1").expect("write new");
+            writeln!(f, "new2").expect("write new");
+        });
+
+        let state = State::builder()
+            .state(json!({"path": path_str, "expected": 4}))
+            .build();
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(5),
+            runner.invoke().state(state).call(),
+        )
+        .await
+        .expect("should not timeout")
+        .expect("invoke");
+
+        rotator.await.expect("rotator task");
+        assert_eq!(
+            json!(["old1", "old2", "new1", "new2"]),
+            result.result.expect("result")
+        );
+    }
+```
+
+- [ ] **Step 3: Run test**
+
+Run: `cd /home/nixos/Develop/claude/lmb && cargo nextest run test_tail_rotation`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/fixtures/bindings/fs/tail-rotation.lua src/bindings/fs.rs
+git commit -m "test(fs): add tail rotation detection test"
+```
+
+---
+
+### Task 8: Test file does not exist
+
+**Files:**
+- Create: `src/fixtures/bindings/fs/tail-file-not-exists.lua`
+- Modify: `src/bindings/fs.rs` (add test)
+
+- [ ] **Step 1: Create Lua fixture**
+
+```lua
+function tail_not_exists(ctx)
+  local fs = require("@lmb/fs")
+  local result = {}
+  for line in fs:tail(ctx.state.path, { from = "start", poll_interval = 50 }) do
+    table.insert(result, line)
+    if #result >= ctx.state.expected then
+      break
+    end
+  end
+  return result
+end
+
+return tail_not_exists
+```
+
+- [ ] **Step 2: Write the test**
+
+Add to `mod tests`:
+
+```rust
+    #[tokio::test]
+    async fn test_tail_file_not_exists() {
+        let dir = TempDir::new().expect("create temp dir");
+        let file_path = dir.path().join("future.log");
+        let path_str = file_path.to_string_lossy().to_string();
+        let dir_path = dir.path().to_path_buf();
+
+        let source = include_str!("../fixtures/bindings/fs/tail-file-not-exists.lua");
+        let perm = fs_permissions(
+            ReadPermissions::Some {
+                allowed: [dir_path].into_iter().collect(),
+                denied: Default::default(),
+            },
+            WritePermissions::Some {
+                allowed: Default::default(),
+                denied: Default::default(),
+            },
+        );
+        let runner = Runner::builder(source, empty())
+            .permissions(perm)
+            .build()
+            .expect("build runner");
+
+        let create_path = file_path.clone();
+        let creator = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(300)).await;
+            let mut f = File::create(&create_path).expect("create file");
+            writeln!(f, "appeared1").expect("write");
+            writeln!(f, "appeared2").expect("write");
+        });
+
+        let state = State::builder()
+            .state(json!({"path": path_str, "expected": 2}))
+            .build();
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(5),
+            runner.invoke().state(state).call(),
+        )
+        .await
+        .expect("should not timeout")
+        .expect("invoke");
+
+        creator.await.expect("creator task");
+        assert_eq!(
+            json!(["appeared1", "appeared2"]),
+            result.result.expect("result")
+        );
+    }
+```
+
+- [ ] **Step 3: Run test**
+
+Run: `cd /home/nixos/Develop/claude/lmb && cargo nextest run test_tail_file_not_exists`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/fixtures/bindings/fs/tail-file-not-exists.lua src/bindings/fs.rs
+git commit -m "test(fs): add tail file-not-exists test"
+```
+
+---
+
+### Task 9: Run all tests and final verification
+
+- [ ] **Step 1: Run all fs tests**
+
+Run: `cd /home/nixos/Develop/claude/lmb && cargo nextest run`
+Expected: all tests pass, no regressions
+
+- [ ] **Step 2: Run clippy**
+
+Run: `cd /home/nixos/Develop/claude/lmb && cargo clippy -- -D warnings`
+Expected: no warnings
+
+- [ ] **Step 3: Commit any fixes if needed**
+
+If clippy or tests reveal issues, fix and commit.

--- a/docs/superpowers/specs/2026-03-17-fs-tail-design.md
+++ b/docs/superpowers/specs/2026-03-17-fs-tail-design.md
@@ -46,8 +46,8 @@ Returns a Lua iterator function for use in `for...in` loops. The iterator yields
 | File rotated (inode change or size shrink) | Reopen the file at the same path, read from beginning |
 | File does not exist yet | Wait (polling) until the file appears, then start reading |
 | File temporarily missing (rotate gap) | Keep waiting, resume when file reappears |
-| `break` in for loop | Exit loop normally, no cleanup needed |
-| Permission denied | Error at call time (before iterator starts), consistent with `fs.lines()` |
+| `break` in for loop | Exit loop normally. The `TailState` (including open `File` handle) is held by `Arc<Mutex<...>>` inside the closure; it is released when the closure is garbage-collected. This is non-deterministic but safe — consistent with how `fs.lines()` handles its file handle. |
+| Permission denied | Check the **parent directory** for read permission at call time (before iterator starts). The file itself may not exist yet, so we cannot canonicalize it. If the parent directory is not readable, return an error immediately. |
 
 ## Rotation Detection
 
@@ -60,11 +60,15 @@ On each poll cycle (when EOF is reached and before sleeping):
 
 This matches the behavior of `tail -F` (capital F) in GNU coreutils.
 
+**Known limitation (TOCTOU race):** There is a small window between stat and read where rotation could occur. If the file is rotated between these two operations, we may briefly read from the old file descriptor. This is the same race condition that GNU `tail -F` has and is acceptable — the next poll cycle will detect the inode change and correct itself. After reopening, we re-stat to verify the inode matches the newly opened file.
+
 ## Implementation
 
-### Approach: Polling with Sleep
+### Approach: Polling with Async Sleep
 
-Uses a synchronous polling loop inside the iterator closure. This matches the existing `fs.lines()` pattern (synchronous `add_method`, closure returning lines).
+Uses `add_async_function` with `tokio::time::sleep` for the polling wait. This is critical because LMB runs Lua scripts directly on the Tokio runtime via `call_async` — there is no `spawn_blocking` or dedicated thread pool. Using `std::thread::sleep` would block a Tokio worker thread indefinitely.
+
+The iterator closure is registered as an async function so that `tokio::time::sleep` yields control back to the runtime between poll cycles. The existing `fs.lines()` uses synchronous `add_method` because it terminates at EOF; `fs.tail` runs indefinitely and must not monopolize a runtime thread.
 
 **Why polling over inotify/notify:**
 - No new dependencies, no impact on binary size (LMB targets lightweight deployments)
@@ -78,28 +82,41 @@ New method added to `FsBinding::add_methods` in `src/bindings/fs.rs`:
 
 ```rust
 methods.add_method("tail", |vm, this, (path, options): (String, Option<LuaTable>)| {
-    this.check_read_permission(&path).map_err(LuaError::runtime)?;
+    // Permission check: verify parent directory is readable (file may not exist yet)
+    let parent = Path::new(&path).parent().unwrap_or(Path::new("."));
+    this.check_read_permission(&parent.to_string_lossy())
+        .map_err(LuaError::runtime)?;
 
     let poll_interval = /* extract from options, default 100 */;
     let from_end = /* extract from options, default true */;
 
     let state = Arc::new(Mutex::new(TailState::new(path, poll_interval, from_end)));
 
-    vm.create_function(move |vm, ()| {
-        let mut state = state.lock();
-        loop {
-            // 1. Ensure file is open (wait if not exists)
-            state.ensure_open();
+    // Use async function so tokio::time::sleep yields the runtime thread
+    vm.create_async_function(move |vm, ()| {
+        let state = state.clone();
+        async move {
+            loop {
+                let result = {
+                    let mut state = state.lock();
 
-            // 2. Check for rotation (inode/size change)
-            state.check_rotation();
+                    // 1. Ensure file is open (if not exists, will return None)
+                    state.ensure_open();
 
-            // 3. Try to read a line
-            match state.read_line() {
-                Some(line) => return vm.create_string(&line).map(LuaValue::String),
-                None => {
-                    // EOF — sleep and retry
-                    std::thread::sleep(Duration::from_millis(state.poll_interval));
+                    // 2. Check for rotation (inode/size change)
+                    state.check_rotation();
+
+                    // 3. Try to read a line
+                    state.read_line()
+                };
+                // Lock released before await point
+
+                match result {
+                    Some(line) => return vm.create_string(&line).map(LuaValue::String),
+                    None => {
+                        // EOF or file not ready — async sleep, yield runtime thread
+                        tokio::time::sleep(Duration::from_millis(poll_interval)).await;
+                    }
                 }
             }
         }
@@ -107,18 +124,23 @@ methods.add_method("tail", |vm, this, (path, options): (String, Option<LuaTable>
 });
 ```
 
+**Important:** The `Mutex` lock is released before the `.await` point to avoid holding it across the async sleep. This prevents deadlocks and allows other Lua coroutines to make progress.
+
 ### `TailState` Struct
 
 ```rust
 struct TailState {
     path: PathBuf,
     reader: Option<BufReader<File>>,
-    inode: u64,              // Last known inode (via std::os::unix::fs::MetadataExt on Unix)
+    inode: Option<u64>,      // Last known inode (None until first successful open)
+                             // Uses std::os::unix::fs::MetadataExt::ino() on Unix
     position: u64,           // Current read position
     poll_interval: u64,      // Milliseconds
     from_end: bool,          // Whether to seek to end on first open
 }
 ```
+
+**Initial state:** `inode` starts as `None`. The first successful `open` records the inode without triggering rotation detection. Subsequent opens compare against the stored value — a mismatch means rotation occurred.
 
 **Platform note:** Inode tracking uses `std::os::unix::fs::MetadataExt::ino()` which is Unix-only. On non-Unix platforms, rotation detection falls back to size-only checks (file size shrinking). This is acceptable since LMB's primary target is Linux.
 
@@ -126,11 +148,11 @@ struct TailState {
 
 | Aspect | Approach |
 |--------|----------|
-| **Permission check** | Reuses `check_read_permission()` at call time, same as `fs.lines()` |
-| **Method registration** | `add_method("tail", ...)` alongside existing methods in `FsBinding::add_methods` |
+| **Permission check** | Checks **parent directory** read permission at call time (file may not exist yet). Uses existing `check_read_permission()`. |
+| **Method registration** | `add_method("tail", ...)` returns an async closure via `vm.create_async_function`, alongside existing methods in `FsBinding::add_methods` |
 | **Line trimming** | Strips trailing `\n` and `\r`, consistent with `fs.lines()` and `FileHandleBinding::read("*l")` |
 | **Error handling** | IO errors during read are reported via `LuaError`, consistent with other fs methods |
-| **Thread blocking** | Uses `std::thread::sleep` in the polling loop. This blocks the current thread, which is acceptable because LMB runs Lua scripts on dedicated threads (or blocking tasks). The Tokio async runtime is not blocked. |
+| **Async runtime** | Uses `tokio::time::sleep` (not `std::thread::sleep`) because LMB runs Lua via `call_async` directly on Tokio worker threads. The Mutex lock is released before each await point. |
 
 ### Documentation Update
 

--- a/docs/superpowers/specs/2026-03-17-fs-tail-design.md
+++ b/docs/superpowers/specs/2026-03-17-fs-tail-design.md
@@ -1,0 +1,157 @@
+# `fs.tail` — File Tail Follow for `@lmb/fs`
+
+## Overview
+
+Add a `tail(path, options?)` method to the `@lmb/fs` module that returns a line iterator which follows a file indefinitely, similar to `tail -F`. The iterator yields new lines as they are appended and automatically follows file rotations (e.g., logrotate).
+
+## API
+
+```lua
+local fs = require("@lmb/fs")
+
+-- Basic usage: follow from end of file
+for line in fs.tail("/var/log/nginx/access.log") do
+    if line:match("500") then
+        -- handle error line
+    end
+end
+
+-- With options
+for line in fs.tail("/var/log/nginx/access.log", {
+    poll_interval = 200,    -- milliseconds, default: 100
+    from = "end",           -- "end" (default) = start from file tail / "start" = read from beginning
+}) do
+    print(line)
+end
+```
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `path` | string | required | File path to tail |
+| `options.poll_interval` | number | `100` | Milliseconds to sleep when no new data is available |
+| `options.from` | string | `"end"` | Where to start reading: `"end"` skips existing content, `"start"` reads from beginning |
+
+### Return Value
+
+Returns a Lua iterator function for use in `for...in` loops. The iterator yields one line (string) per call, with trailing newlines stripped (consistent with `fs.lines()`).
+
+## Behavior
+
+| Scenario | Behavior |
+|----------|----------|
+| New line available | Return immediately, no sleep |
+| At EOF (no new data) | Sleep `poll_interval` ms, then retry |
+| File rotated (inode change or size shrink) | Reopen the file at the same path, read from beginning |
+| File does not exist yet | Wait (polling) until the file appears, then start reading |
+| File temporarily missing (rotate gap) | Keep waiting, resume when file reappears |
+| `break` in for loop | Exit loop normally, no cleanup needed |
+| Permission denied | Error at call time (before iterator starts), consistent with `fs.lines()` |
+
+## Rotation Detection
+
+On each poll cycle (when EOF is reached and before sleeping):
+
+1. Stat the path to get current inode and file size
+2. If inode differs from the last known inode → file has been rotated → reopen and read from beginning
+3. If file size is smaller than current read position → file has been truncated → seek to beginning
+4. If stat fails (file gone) → enter waiting mode, keep polling until file reappears
+
+This matches the behavior of `tail -F` (capital F) in GNU coreutils.
+
+## Implementation
+
+### Approach: Polling with Sleep
+
+Uses a synchronous polling loop inside the iterator closure. This matches the existing `fs.lines()` pattern (synchronous `add_method`, closure returning lines).
+
+**Why polling over inotify/notify:**
+- No new dependencies, no impact on binary size (LMB targets lightweight deployments)
+- Consistent behavior across all platforms and filesystems (including NFS where inotify does not work)
+- 100ms polling interval has negligible CPU cost (10 syscalls/second when idle)
+- GNU `tail -f` itself uses polling as its default strategy
+
+### Rust Implementation
+
+New method added to `FsBinding::add_methods` in `src/bindings/fs.rs`:
+
+```rust
+methods.add_method("tail", |vm, this, (path, options): (String, Option<LuaTable>)| {
+    this.check_read_permission(&path).map_err(LuaError::runtime)?;
+
+    let poll_interval = /* extract from options, default 100 */;
+    let from_end = /* extract from options, default true */;
+
+    let state = Arc::new(Mutex::new(TailState::new(path, poll_interval, from_end)));
+
+    vm.create_function(move |vm, ()| {
+        let mut state = state.lock();
+        loop {
+            // 1. Ensure file is open (wait if not exists)
+            state.ensure_open();
+
+            // 2. Check for rotation (inode/size change)
+            state.check_rotation();
+
+            // 3. Try to read a line
+            match state.read_line() {
+                Some(line) => return vm.create_string(&line).map(LuaValue::String),
+                None => {
+                    // EOF — sleep and retry
+                    std::thread::sleep(Duration::from_millis(state.poll_interval));
+                }
+            }
+        }
+    })
+});
+```
+
+### `TailState` Struct
+
+```rust
+struct TailState {
+    path: PathBuf,
+    reader: Option<BufReader<File>>,
+    inode: u64,              // Last known inode (via std::os::unix::fs::MetadataExt on Unix)
+    position: u64,           // Current read position
+    poll_interval: u64,      // Milliseconds
+    from_end: bool,          // Whether to seek to end on first open
+}
+```
+
+**Platform note:** Inode tracking uses `std::os::unix::fs::MetadataExt::ino()` which is Unix-only. On non-Unix platforms, rotation detection falls back to size-only checks (file size shrinking). This is acceptable since LMB's primary target is Linux.
+
+### Integration with Existing Code
+
+| Aspect | Approach |
+|--------|----------|
+| **Permission check** | Reuses `check_read_permission()` at call time, same as `fs.lines()` |
+| **Method registration** | `add_method("tail", ...)` alongside existing methods in `FsBinding::add_methods` |
+| **Line trimming** | Strips trailing `\n` and `\r`, consistent with `fs.lines()` and `FileHandleBinding::read("*l")` |
+| **Error handling** | IO errors during read are reported via `LuaError`, consistent with other fs methods |
+| **Thread blocking** | Uses `std::thread::sleep` in the polling loop. This blocks the current thread, which is acceptable because LMB runs Lua scripts on dedicated threads (or blocking tasks). The Tokio async runtime is not blocked. |
+
+### Documentation Update
+
+Add to the module doc comment at top of `fs.rs`:
+
+```
+//! - `tail(path, options)` - Follow a file like `tail -F`, returning a line iterator that
+//!   yields new lines as they are appended. Automatically follows file rotations.
+```
+
+## Testing
+
+All tests in `src/bindings/fs.rs` `mod tests`, using `tempfile` for test fixtures:
+
+1. **Basic read** — Write lines to a file, `tail` with `from = "start"`, verify all lines are yielded
+2. **Wait for new lines** — Tail an existing file (hits EOF), spawn a thread that writes new lines after a delay, verify the new lines are received
+3. **Rotation detection** — Tail a file, rename it, create a new file at the same path, write to the new file, verify tail follows the new file
+4. **File does not exist** — Tail a non-existent path, spawn a thread that creates the file after a delay, verify lines are received once the file appears
+5. **Break exits cleanly** — Tail a file, break after N lines, verify no panic or resource leak
+6. **Permission denied** — Tail a path without read permission, verify error is returned
+
+## Configuration Reference
+
+No new CLI flags or environment variables. Configuration is per-call via the options table.

--- a/docs/superpowers/specs/2026-03-17-fs-tail-design.md
+++ b/docs/superpowers/specs/2026-03-17-fs-tail-design.md
@@ -1,97 +1,97 @@
-# `fs.tail` — `@lmb/fs` 檔案追蹤功能
+# `fs.tail` — File Tail Follow for `@lmb/fs`
 
-## 概述
+## Overview
 
-在 `@lmb/fs` 模組中新增 `tail(path, options?)` 方法，回傳一個無限迭代器，持續追蹤檔案新增的行，類似 `tail -F`。自動偵測檔案輪替（logrotate）並跟隨新檔案。
+Add a `tail(path, options?)` method to the `@lmb/fs` module that returns a line iterator which follows a file indefinitely, similar to `tail -F`. The iterator yields new lines as they are appended and automatically follows file rotations (e.g., logrotate).
 
 ## API
 
 ```lua
 local fs = require("@lmb/fs")
 
--- 基本用法：從檔案尾端開始追蹤
+-- Basic usage: follow from end of file
 for line in fs.tail("/var/log/nginx/access.log") do
     if line:match("500") then
-        -- 處理錯誤行
+        -- handle error line
     end
 end
 
--- 帶選項
+-- With options
 for line in fs.tail("/var/log/nginx/access.log", {
-    poll_interval = 200,    -- 毫秒，預設 100
-    from = "end",           -- "end"（預設）= 從尾端開始 / "start" = 從頭開始
+    poll_interval = 200,    -- milliseconds, default: 100
+    from = "end",           -- "end" (default) = start from file tail / "start" = read from beginning
 }) do
     print(line)
 end
 ```
 
-### 參數
+### Parameters
 
-| 參數 | 型別 | 預設值 | 說明 |
-|------|------|--------|------|
-| `path` | string | 必填 | 要追蹤的檔案路徑 |
-| `options.poll_interval` | number | `100` | 無新資料時的輪詢間隔（毫秒） |
-| `options.from` | string | `"end"` | 起始位置：`"end"` 跳過既有內容，`"start"` 從頭讀取 |
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `path` | string | required | File path to tail |
+| `options.poll_interval` | number | `100` | Milliseconds to sleep when no new data is available |
+| `options.from` | string | `"end"` | Where to start reading: `"end"` skips existing content, `"start"` reads from beginning |
 
-### 回傳值
+### Return Value
 
-回傳一個 Lua 迭代器函數，供 `for...in` 迴圈使用。每次呼叫產出一行（string），尾端換行已去除（與 `fs.lines()` 行為一致）。
+Returns a Lua iterator function for use in `for...in` loops. The iterator yields one line (string) per call, with trailing newlines stripped (consistent with `fs.lines()`).
 
-## 行為
+## Behavior
 
-| 情境 | 行為 |
-|------|------|
-| 有新行可讀 | 立即回傳，不 sleep |
-| 到達 EOF（無新資料） | sleep `poll_interval` 毫秒後重試 |
-| 檔案被輪替（inode 變更或大小縮小） | 以同路徑重新開啟新檔案，從頭讀取 |
-| 檔案尚不存在 | 持續輪詢等待檔案出現，出現後開始讀取 |
-| 檔案暫時消失（輪替空窗期） | 持續等待，檔案重新出現後繼續 |
-| 迴圈中 `break` | 正常離開迴圈。`TailState`（含開啟的 `File` handle）由 `Arc<Mutex<...>>` 持有，在 closure 被 GC 回收時釋放。這是非確定性的，但安全——與 `fs.lines()` 處理方式一致。 |
-| 權限不足 | 在呼叫時（迭代器開始前）呼叫 `check_read_permission(path)`。既有的 `canonicalize_for_check` 已能處理檔案不存在的情況（透過正規化父目錄並附加檔名）。 |
+| Scenario | Behavior |
+|----------|----------|
+| New line available | Return immediately, no sleep |
+| At EOF (no new data) | Sleep `poll_interval` ms, then retry |
+| File rotated (inode change or size shrink) | Reopen the file at the same path, read from beginning |
+| File does not exist yet | Wait (polling) until the file appears, then start reading |
+| File temporarily missing (rotate gap) | Keep waiting, resume when file reappears |
+| `break` in for loop | Exit loop normally. The `TailState` (including open `File` handle) is held by `Arc<Mutex<...>>` inside the closure; it is released when the closure is garbage-collected. This is non-deterministic but safe — consistent with how `fs.lines()` handles its file handle. |
+| Permission denied | Call `check_read_permission(path)` at call time (before iterator starts). The existing `canonicalize_for_check` already handles non-existent files by canonicalizing the parent directory and appending the filename. |
 
-## 輪替偵測
+## Rotation Detection
 
-每次輪詢週期（到達 EOF 後、sleep 前）：
+On each poll cycle (when EOF is reached and before sleeping):
 
-1. 對路徑執行 stat 取得當前 inode 與檔案大小
-2. inode 與上次記錄不同 → 檔案已被輪替 → 重新開啟並從頭讀取
-3. 檔案大小小於當前讀取位置 → 檔案被截斷 → seek 回開頭
-4. stat 失敗（檔案消失）→ 進入等待模式，持續輪詢直到檔案重新出現
+1. Stat the path to get current inode and file size
+2. If inode differs from the last known inode → file has been rotated → reopen and read from beginning
+3. If file size is smaller than current read position → file has been truncated → seek to beginning
+4. If stat fails (file gone) → enter waiting mode, keep polling until file reappears
 
-此行為與 GNU coreutils 的 `tail -F`（大寫 F）一致。
+This matches the behavior of `tail -F` (capital F) in GNU coreutils.
 
-**已知限制（TOCTOU 競爭）：** stat 與 read 之間存在一個小窗口，期間可能發生輪替。如果檔案在這兩個操作之間被輪替，可能短暫地從舊的 file descriptor 讀取。這與 GNU `tail -F` 的已知限制相同，是可接受的——下一次輪詢週期會偵測到 inode 變化並自動修正。重新開啟後會再次 stat 以確認 inode 與新開啟的檔案一致。
+**Known limitation (TOCTOU race):** There is a small window between stat and read where rotation could occur. If the file is rotated between these two operations, we may briefly read from the old file descriptor. This is the same race condition that GNU `tail -F` has and is acceptable — the next poll cycle will detect the inode change and correct itself. After reopening, we re-stat to verify the inode matches the newly opened file.
 
-## 實作
+## Implementation
 
-### 方式：非同步輪詢
+### Approach: Polling with Async Sleep
 
-使用 `add_method` 搭配 `vm.create_async_function` 與 `tokio::time::sleep` 進行輪詢等待。這是必要的，因為 LMB 透過 `call_async` 直接在 Tokio runtime 上執行 Lua 腳本——沒有 `spawn_blocking` 或專用的執行緒池。使用 `std::thread::sleep` 會無限期阻塞 Tokio worker thread。
+Uses `add_async_function` with `tokio::time::sleep` for the polling wait. This is critical because LMB runs Lua scripts directly on the Tokio runtime via `call_async` — there is no `spawn_blocking` or dedicated thread pool. Using `std::thread::sleep` would block a Tokio worker thread indefinitely.
 
-迭代器 closure 註冊為 async function，使得 `tokio::time::sleep` 能在輪詢週期之間讓出 runtime thread。既有的 `fs.lines()` 使用同步 `add_method` 是因為它在 EOF 時終止；`fs.tail` 無限期運行，不可獨佔 runtime thread。
+The iterator closure is registered as an async function so that `tokio::time::sleep` yields control back to the runtime between poll cycles. The existing `fs.lines()` uses synchronous `add_method` because it terminates at EOF; `fs.tail` runs indefinitely and must not monopolize a runtime thread.
 
-**為何選擇輪詢而非 inotify/notify：**
-- 不引入新依賴，不影響 binary 大小（LMB 以輕量部署為目標）
-- 所有平台與檔案系統行為一致（包括 inotify 不工作的 NFS）
-- 100ms 輪詢間隔的 CPU 成本可忽略（閒置時每秒 10 次 syscall）
-- GNU `tail -f` 本身預設也使用輪詢
+**Why polling over inotify/notify:**
+- No new dependencies, no impact on binary size (LMB targets lightweight deployments)
+- Consistent behavior across all platforms and filesystems (including NFS where inotify does not work)
+- 100ms polling interval has negligible CPU cost (10 syscalls/second when idle)
+- GNU `tail -f` itself uses polling as its default strategy
 
-### Rust 實作
+### Rust Implementation
 
-在 `src/bindings/fs.rs` 的 `FsBinding::add_methods` 中新增方法：
+New method added to `FsBinding::add_methods` in `src/bindings/fs.rs`:
 
 ```rust
 methods.add_method("tail", |vm, this, (path, options): (String, Option<LuaTable>)| {
-    // 權限檢查：傳入完整路徑。check_read_permission -> canonicalize_for_check
-    // 已能處理不存在的檔案（正規化父目錄並附加檔名）。
+    // Permission check: pass full file path. check_read_permission -> canonicalize_for_check
+    // already handles non-existent files by canonicalizing the parent dir and appending filename.
     this.check_read_permission(&path).map_err(LuaError::runtime)?;
 
-    let poll_interval = /* 從 options 取得，預設 100 */;
-    let from_end = /* 從 options 取得，預設 true */;
+    let poll_interval = /* extract from options, default 100 */;
+    let from_end = /* extract from options, default true */;
 
     let state = Arc::new(Mutex::new(TailState::new(path, poll_interval, from_end)));
 
-    // 使用 async function 使 tokio::time::sleep 能讓出 runtime thread
+    // Use async function so tokio::time::sleep yields the runtime thread
     vm.create_async_function(move |vm, ()| {
         let state = state.clone();
         async move {
@@ -99,21 +99,21 @@ methods.add_method("tail", |vm, this, (path, options): (String, Option<LuaTable>
                 let result = {
                     let mut state = state.lock();
 
-                    // 1. 確保檔案已開啟（不存在則回傳 None）
+                    // 1. Ensure file is open (if not exists, will return None)
                     state.ensure_open();
 
-                    // 2. 檢查輪替（inode/大小變化）
+                    // 2. Check for rotation (inode/size change)
                     state.check_rotation();
 
-                    // 3. 嘗試讀取一行
+                    // 3. Try to read a line
                     state.read_line()
                 };
-                // await 前釋放鎖
+                // Lock released before await point
 
                 match result {
                     Some(line) => return vm.create_string(&line).map(LuaValue::String),
                     None => {
-                        // EOF 或檔案未就緒——非同步 sleep，讓出 runtime thread
+                        // EOF or file not ready — async sleep, yield runtime thread
                         tokio::time::sleep(Duration::from_millis(poll_interval)).await;
                     }
                 }
@@ -123,58 +123,58 @@ methods.add_method("tail", |vm, this, (path, options): (String, Option<LuaTable>
 });
 ```
 
-**重要事項：**
-- `parking_lot::Mutex` 鎖（與 `fs.rs` 其餘部分一致）在 `.await` 點前釋放，避免跨 async sleep 持有鎖。這防止死鎖並允許其他 Lua coroutine 繼續執行。
-- `fs.tail()` 要求 Lua 腳本透過 `call_async` 執行（LMB 的正常執行路徑）。若從同步上下文呼叫 async 迭代器會 panic。這與 `io.read` 及其他 async binding 的前提條件相同。
+**Important:**
+- The `parking_lot::Mutex` lock (consistent with the rest of `fs.rs`) is released before the `.await` point to avoid holding it across the async sleep. This prevents deadlocks and allows other Lua coroutines to make progress.
+- `fs.tail()` requires the Lua script to be executed via `call_async` (the normal execution path in LMB). The async iterator function will panic if called from a synchronous Lua context. This is the same precondition that applies to `io.read` and other async bindings in LMB.
 
-### `TailState` 結構
+### `TailState` Struct
 
 ```rust
 struct TailState {
     path: PathBuf,
     reader: Option<BufReader<File>>,
-    inode: Option<u64>,      // 上次已知的 inode（首次成功開啟前為 None）
-                             // Unix 上使用 std::os::unix::fs::MetadataExt::ino()
-    position: u64,           // 目前讀取位置
-    poll_interval: u64,      // 毫秒
-    from_end: bool,          // 首次開啟時是否 seek 到尾端
+    inode: Option<u64>,      // Last known inode (None until first successful open)
+                             // Uses std::os::unix::fs::MetadataExt::ino() on Unix
+    position: u64,           // Current read position
+    poll_interval: u64,      // Milliseconds
+    from_end: bool,          // Whether to seek to end on first open
 }
 ```
 
-**初始狀態：** `inode` 初始為 `None`。首次成功開啟時記錄 inode，不觸發「偵測到輪替」。後續開啟時比較已儲存的值——不一致表示發生了輪替。
+**Initial state:** `inode` starts as `None`. The first successful `open` records the inode without triggering rotation detection. Subsequent opens compare against the stored value — a mismatch means rotation occurred.
 
-**平台說明：** inode 追蹤使用 `std::os::unix::fs::MetadataExt::ino()`，僅限 Unix。非 Unix 平台上輪替偵測退化為僅檢查大小變化（檔案大小縮小）。這是可接受的，因為 LMB 主要目標平台是 Linux。
+**Platform note:** Inode tracking uses `std::os::unix::fs::MetadataExt::ino()` which is Unix-only. On non-Unix platforms, rotation detection falls back to size-only checks (file size shrinking). This is acceptable since LMB's primary target is Linux.
 
-### 與既有程式碼的整合
+### Integration with Existing Code
 
-| 面向 | 做法 |
-|------|------|
-| **權限檢查** | 在呼叫時使用 `check_read_permission(path)`。`canonicalize_for_check` 已能處理不存在的檔案（正規化父目錄並附加檔名）。 |
-| **方法註冊** | `add_method("tail", ...)` 回傳 async closure（透過 `vm.create_async_function`），與 `FsBinding::add_methods` 中的既有方法並列 |
-| **行尾處理** | 去除尾端 `\n` 和 `\r`，與 `fs.lines()` 及 `FileHandleBinding::read("*l")` 一致 |
-| **錯誤處理** | 讀取時的 IO 錯誤透過 `LuaError` 回報，與其他 fs 方法一致 |
-| **非同步 runtime** | 使用 `tokio::time::sleep`（非 `std::thread::sleep`），因為 LMB 透過 `call_async` 直接在 Tokio worker thread 上執行 Lua。`Mutex` 鎖在每個 await 點前釋放。 |
+| Aspect | Approach |
+|--------|----------|
+| **Permission check** | Reuses `check_read_permission(path)` at call time. `canonicalize_for_check` already handles non-existent files by canonicalizing the parent and appending the filename. |
+| **Method registration** | `add_method("tail", ...)` returns an async closure via `vm.create_async_function`, alongside existing methods in `FsBinding::add_methods` |
+| **Line trimming** | Strips trailing `\n` and `\r`, consistent with `fs.lines()` and `FileHandleBinding::read("*l")` |
+| **Error handling** | IO errors during read are reported via `LuaError`, consistent with other fs methods |
+| **Async runtime** | Uses `tokio::time::sleep` (not `std::thread::sleep`) because LMB runs Lua via `call_async` directly on Tokio worker threads. The Mutex lock is released before each await point. |
 
-### 文件更新
+### Documentation Update
 
-在 `fs.rs` 頂部的模組文件註解中新增：
+Add to the module doc comment at top of `fs.rs`:
 
 ```
 //! - `tail(path, options)` - Follow a file like `tail -F`, returning a line iterator that
 //!   yields new lines as they are appended. Automatically follows file rotations.
 ```
 
-## 測試
+## Testing
 
-所有測試位於 `src/bindings/fs.rs` 的 `mod tests` 中，使用 `tempfile` 建立測試檔案：
+All tests in `src/bindings/fs.rs` `mod tests`, using `tempfile` for test fixtures:
 
-1. **基本讀取** — 寫入行到檔案，以 `from = "start"` 呼叫 `tail`，驗證所有行都被產出
-2. **等待新行** — tail 一個既有檔案（到達 EOF），從另一個 thread 延遲寫入新行，驗證能收到新行
-3. **輪替偵測** — tail 一個檔案，重新命名它，在同路徑建立新檔案並寫入，驗證 tail 跟隨新檔案
-4. **檔案不存在** — tail 一個不存在的路徑，從另一個 thread 延遲建立檔案，驗證檔案出現後能收到行
-5. **break 正常離開** — tail 一個檔案，在 N 行後 break，驗證無 panic 或資源洩漏
-6. **權限不足** — 在沒有讀取權限的情況下 tail，驗證回傳錯誤
+1. **Basic read** — Write lines to a file, `tail` with `from = "start"`, verify all lines are yielded
+2. **Wait for new lines** — Tail an existing file (hits EOF), spawn a thread that writes new lines after a delay, verify the new lines are received
+3. **Rotation detection** — Tail a file, rename it, create a new file at the same path, write to the new file, verify tail follows the new file
+4. **File does not exist** — Tail a non-existent path, spawn a thread that creates the file after a delay, verify lines are received once the file appears
+5. **Break exits cleanly** — Tail a file, break after N lines, verify no panic or resource leak
+6. **Permission denied** — Tail a path without read permission, verify error is returned
 
-## 設定參考
+## Configuration Reference
 
-無新增 CLI 旗標或環境變數。設定透過 options table 逐次呼叫指定。
+No new CLI flags or environment variables. Configuration is per-call via the options table.

--- a/docs/superpowers/specs/2026-03-17-fs-tail-design.md
+++ b/docs/superpowers/specs/2026-03-17-fs-tail-design.md
@@ -1,97 +1,97 @@
-# `fs.tail` — File Tail Follow for `@lmb/fs`
+# `fs.tail` — `@lmb/fs` 檔案追蹤功能
 
-## Overview
+## 概述
 
-Add a `tail(path, options?)` method to the `@lmb/fs` module that returns a line iterator which follows a file indefinitely, similar to `tail -F`. The iterator yields new lines as they are appended and automatically follows file rotations (e.g., logrotate).
+在 `@lmb/fs` 模組中新增 `tail(path, options?)` 方法，回傳一個無限迭代器，持續追蹤檔案新增的行，類似 `tail -F`。自動偵測檔案輪替（logrotate）並跟隨新檔案。
 
 ## API
 
 ```lua
 local fs = require("@lmb/fs")
 
--- Basic usage: follow from end of file
+-- 基本用法：從檔案尾端開始追蹤
 for line in fs.tail("/var/log/nginx/access.log") do
     if line:match("500") then
-        -- handle error line
+        -- 處理錯誤行
     end
 end
 
--- With options
+-- 帶選項
 for line in fs.tail("/var/log/nginx/access.log", {
-    poll_interval = 200,    -- milliseconds, default: 100
-    from = "end",           -- "end" (default) = start from file tail / "start" = read from beginning
+    poll_interval = 200,    -- 毫秒，預設 100
+    from = "end",           -- "end"（預設）= 從尾端開始 / "start" = 從頭開始
 }) do
     print(line)
 end
 ```
 
-### Parameters
+### 參數
 
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `path` | string | required | File path to tail |
-| `options.poll_interval` | number | `100` | Milliseconds to sleep when no new data is available |
-| `options.from` | string | `"end"` | Where to start reading: `"end"` skips existing content, `"start"` reads from beginning |
+| 參數 | 型別 | 預設值 | 說明 |
+|------|------|--------|------|
+| `path` | string | 必填 | 要追蹤的檔案路徑 |
+| `options.poll_interval` | number | `100` | 無新資料時的輪詢間隔（毫秒） |
+| `options.from` | string | `"end"` | 起始位置：`"end"` 跳過既有內容，`"start"` 從頭讀取 |
 
-### Return Value
+### 回傳值
 
-Returns a Lua iterator function for use in `for...in` loops. The iterator yields one line (string) per call, with trailing newlines stripped (consistent with `fs.lines()`).
+回傳一個 Lua 迭代器函數，供 `for...in` 迴圈使用。每次呼叫產出一行（string），尾端換行已去除（與 `fs.lines()` 行為一致）。
 
-## Behavior
+## 行為
 
-| Scenario | Behavior |
-|----------|----------|
-| New line available | Return immediately, no sleep |
-| At EOF (no new data) | Sleep `poll_interval` ms, then retry |
-| File rotated (inode change or size shrink) | Reopen the file at the same path, read from beginning |
-| File does not exist yet | Wait (polling) until the file appears, then start reading |
-| File temporarily missing (rotate gap) | Keep waiting, resume when file reappears |
-| `break` in for loop | Exit loop normally. The `TailState` (including open `File` handle) is held by `Arc<Mutex<...>>` inside the closure; it is released when the closure is garbage-collected. This is non-deterministic but safe — consistent with how `fs.lines()` handles its file handle. |
-| Permission denied | Call `check_read_permission(path)` at call time (before iterator starts). The existing `canonicalize_for_check` already handles non-existent files by canonicalizing the parent directory and appending the filename. |
+| 情境 | 行為 |
+|------|------|
+| 有新行可讀 | 立即回傳，不 sleep |
+| 到達 EOF（無新資料） | sleep `poll_interval` 毫秒後重試 |
+| 檔案被輪替（inode 變更或大小縮小） | 以同路徑重新開啟新檔案，從頭讀取 |
+| 檔案尚不存在 | 持續輪詢等待檔案出現，出現後開始讀取 |
+| 檔案暫時消失（輪替空窗期） | 持續等待，檔案重新出現後繼續 |
+| 迴圈中 `break` | 正常離開迴圈。`TailState`（含開啟的 `File` handle）由 `Arc<Mutex<...>>` 持有，在 closure 被 GC 回收時釋放。這是非確定性的，但安全——與 `fs.lines()` 處理方式一致。 |
+| 權限不足 | 在呼叫時（迭代器開始前）呼叫 `check_read_permission(path)`。既有的 `canonicalize_for_check` 已能處理檔案不存在的情況（透過正規化父目錄並附加檔名）。 |
 
-## Rotation Detection
+## 輪替偵測
 
-On each poll cycle (when EOF is reached and before sleeping):
+每次輪詢週期（到達 EOF 後、sleep 前）：
 
-1. Stat the path to get current inode and file size
-2. If inode differs from the last known inode → file has been rotated → reopen and read from beginning
-3. If file size is smaller than current read position → file has been truncated → seek to beginning
-4. If stat fails (file gone) → enter waiting mode, keep polling until file reappears
+1. 對路徑執行 stat 取得當前 inode 與檔案大小
+2. inode 與上次記錄不同 → 檔案已被輪替 → 重新開啟並從頭讀取
+3. 檔案大小小於當前讀取位置 → 檔案被截斷 → seek 回開頭
+4. stat 失敗（檔案消失）→ 進入等待模式，持續輪詢直到檔案重新出現
 
-This matches the behavior of `tail -F` (capital F) in GNU coreutils.
+此行為與 GNU coreutils 的 `tail -F`（大寫 F）一致。
 
-**Known limitation (TOCTOU race):** There is a small window between stat and read where rotation could occur. If the file is rotated between these two operations, we may briefly read from the old file descriptor. This is the same race condition that GNU `tail -F` has and is acceptable — the next poll cycle will detect the inode change and correct itself. After reopening, we re-stat to verify the inode matches the newly opened file.
+**已知限制（TOCTOU 競爭）：** stat 與 read 之間存在一個小窗口，期間可能發生輪替。如果檔案在這兩個操作之間被輪替，可能短暫地從舊的 file descriptor 讀取。這與 GNU `tail -F` 的已知限制相同，是可接受的——下一次輪詢週期會偵測到 inode 變化並自動修正。重新開啟後會再次 stat 以確認 inode 與新開啟的檔案一致。
 
-## Implementation
+## 實作
 
-### Approach: Polling with Async Sleep
+### 方式：非同步輪詢
 
-Uses `add_async_function` with `tokio::time::sleep` for the polling wait. This is critical because LMB runs Lua scripts directly on the Tokio runtime via `call_async` — there is no `spawn_blocking` or dedicated thread pool. Using `std::thread::sleep` would block a Tokio worker thread indefinitely.
+使用 `add_method` 搭配 `vm.create_async_function` 與 `tokio::time::sleep` 進行輪詢等待。這是必要的，因為 LMB 透過 `call_async` 直接在 Tokio runtime 上執行 Lua 腳本——沒有 `spawn_blocking` 或專用的執行緒池。使用 `std::thread::sleep` 會無限期阻塞 Tokio worker thread。
 
-The iterator closure is registered as an async function so that `tokio::time::sleep` yields control back to the runtime between poll cycles. The existing `fs.lines()` uses synchronous `add_method` because it terminates at EOF; `fs.tail` runs indefinitely and must not monopolize a runtime thread.
+迭代器 closure 註冊為 async function，使得 `tokio::time::sleep` 能在輪詢週期之間讓出 runtime thread。既有的 `fs.lines()` 使用同步 `add_method` 是因為它在 EOF 時終止；`fs.tail` 無限期運行，不可獨佔 runtime thread。
 
-**Why polling over inotify/notify:**
-- No new dependencies, no impact on binary size (LMB targets lightweight deployments)
-- Consistent behavior across all platforms and filesystems (including NFS where inotify does not work)
-- 100ms polling interval has negligible CPU cost (10 syscalls/second when idle)
-- GNU `tail -f` itself uses polling as its default strategy
+**為何選擇輪詢而非 inotify/notify：**
+- 不引入新依賴，不影響 binary 大小（LMB 以輕量部署為目標）
+- 所有平台與檔案系統行為一致（包括 inotify 不工作的 NFS）
+- 100ms 輪詢間隔的 CPU 成本可忽略（閒置時每秒 10 次 syscall）
+- GNU `tail -f` 本身預設也使用輪詢
 
-### Rust Implementation
+### Rust 實作
 
-New method added to `FsBinding::add_methods` in `src/bindings/fs.rs`:
+在 `src/bindings/fs.rs` 的 `FsBinding::add_methods` 中新增方法：
 
 ```rust
 methods.add_method("tail", |vm, this, (path, options): (String, Option<LuaTable>)| {
-    // Permission check: pass full file path. check_read_permission -> canonicalize_for_check
-    // already handles non-existent files by canonicalizing the parent dir and appending filename.
+    // 權限檢查：傳入完整路徑。check_read_permission -> canonicalize_for_check
+    // 已能處理不存在的檔案（正規化父目錄並附加檔名）。
     this.check_read_permission(&path).map_err(LuaError::runtime)?;
 
-    let poll_interval = /* extract from options, default 100 */;
-    let from_end = /* extract from options, default true */;
+    let poll_interval = /* 從 options 取得，預設 100 */;
+    let from_end = /* 從 options 取得，預設 true */;
 
     let state = Arc::new(Mutex::new(TailState::new(path, poll_interval, from_end)));
 
-    // Use async function so tokio::time::sleep yields the runtime thread
+    // 使用 async function 使 tokio::time::sleep 能讓出 runtime thread
     vm.create_async_function(move |vm, ()| {
         let state = state.clone();
         async move {
@@ -99,21 +99,21 @@ methods.add_method("tail", |vm, this, (path, options): (String, Option<LuaTable>
                 let result = {
                     let mut state = state.lock();
 
-                    // 1. Ensure file is open (if not exists, will return None)
+                    // 1. 確保檔案已開啟（不存在則回傳 None）
                     state.ensure_open();
 
-                    // 2. Check for rotation (inode/size change)
+                    // 2. 檢查輪替（inode/大小變化）
                     state.check_rotation();
 
-                    // 3. Try to read a line
+                    // 3. 嘗試讀取一行
                     state.read_line()
                 };
-                // Lock released before await point
+                // await 前釋放鎖
 
                 match result {
                     Some(line) => return vm.create_string(&line).map(LuaValue::String),
                     None => {
-                        // EOF or file not ready — async sleep, yield runtime thread
+                        // EOF 或檔案未就緒——非同步 sleep，讓出 runtime thread
                         tokio::time::sleep(Duration::from_millis(poll_interval)).await;
                     }
                 }
@@ -123,58 +123,58 @@ methods.add_method("tail", |vm, this, (path, options): (String, Option<LuaTable>
 });
 ```
 
-**Important:**
-- The `parking_lot::Mutex` lock (consistent with the rest of `fs.rs`) is released before the `.await` point to avoid holding it across the async sleep. This prevents deadlocks and allows other Lua coroutines to make progress.
-- `fs.tail()` requires the Lua script to be executed via `call_async` (the normal execution path in LMB). The async iterator function will panic if called from a synchronous Lua context. This is the same precondition that applies to `io.read` and other async bindings in LMB.
+**重要事項：**
+- `parking_lot::Mutex` 鎖（與 `fs.rs` 其餘部分一致）在 `.await` 點前釋放，避免跨 async sleep 持有鎖。這防止死鎖並允許其他 Lua coroutine 繼續執行。
+- `fs.tail()` 要求 Lua 腳本透過 `call_async` 執行（LMB 的正常執行路徑）。若從同步上下文呼叫 async 迭代器會 panic。這與 `io.read` 及其他 async binding 的前提條件相同。
 
-### `TailState` Struct
+### `TailState` 結構
 
 ```rust
 struct TailState {
     path: PathBuf,
     reader: Option<BufReader<File>>,
-    inode: Option<u64>,      // Last known inode (None until first successful open)
-                             // Uses std::os::unix::fs::MetadataExt::ino() on Unix
-    position: u64,           // Current read position
-    poll_interval: u64,      // Milliseconds
-    from_end: bool,          // Whether to seek to end on first open
+    inode: Option<u64>,      // 上次已知的 inode（首次成功開啟前為 None）
+                             // Unix 上使用 std::os::unix::fs::MetadataExt::ino()
+    position: u64,           // 目前讀取位置
+    poll_interval: u64,      // 毫秒
+    from_end: bool,          // 首次開啟時是否 seek 到尾端
 }
 ```
 
-**Initial state:** `inode` starts as `None`. The first successful `open` records the inode without triggering rotation detection. Subsequent opens compare against the stored value — a mismatch means rotation occurred.
+**初始狀態：** `inode` 初始為 `None`。首次成功開啟時記錄 inode，不觸發「偵測到輪替」。後續開啟時比較已儲存的值——不一致表示發生了輪替。
 
-**Platform note:** Inode tracking uses `std::os::unix::fs::MetadataExt::ino()` which is Unix-only. On non-Unix platforms, rotation detection falls back to size-only checks (file size shrinking). This is acceptable since LMB's primary target is Linux.
+**平台說明：** inode 追蹤使用 `std::os::unix::fs::MetadataExt::ino()`，僅限 Unix。非 Unix 平台上輪替偵測退化為僅檢查大小變化（檔案大小縮小）。這是可接受的，因為 LMB 主要目標平台是 Linux。
 
-### Integration with Existing Code
+### 與既有程式碼的整合
 
-| Aspect | Approach |
-|--------|----------|
-| **Permission check** | Reuses `check_read_permission(path)` at call time. `canonicalize_for_check` already handles non-existent files by canonicalizing the parent and appending the filename. |
-| **Method registration** | `add_method("tail", ...)` returns an async closure via `vm.create_async_function`, alongside existing methods in `FsBinding::add_methods` |
-| **Line trimming** | Strips trailing `\n` and `\r`, consistent with `fs.lines()` and `FileHandleBinding::read("*l")` |
-| **Error handling** | IO errors during read are reported via `LuaError`, consistent with other fs methods |
-| **Async runtime** | Uses `tokio::time::sleep` (not `std::thread::sleep`) because LMB runs Lua via `call_async` directly on Tokio worker threads. The Mutex lock is released before each await point. |
+| 面向 | 做法 |
+|------|------|
+| **權限檢查** | 在呼叫時使用 `check_read_permission(path)`。`canonicalize_for_check` 已能處理不存在的檔案（正規化父目錄並附加檔名）。 |
+| **方法註冊** | `add_method("tail", ...)` 回傳 async closure（透過 `vm.create_async_function`），與 `FsBinding::add_methods` 中的既有方法並列 |
+| **行尾處理** | 去除尾端 `\n` 和 `\r`，與 `fs.lines()` 及 `FileHandleBinding::read("*l")` 一致 |
+| **錯誤處理** | 讀取時的 IO 錯誤透過 `LuaError` 回報，與其他 fs 方法一致 |
+| **非同步 runtime** | 使用 `tokio::time::sleep`（非 `std::thread::sleep`），因為 LMB 透過 `call_async` 直接在 Tokio worker thread 上執行 Lua。`Mutex` 鎖在每個 await 點前釋放。 |
 
-### Documentation Update
+### 文件更新
 
-Add to the module doc comment at top of `fs.rs`:
+在 `fs.rs` 頂部的模組文件註解中新增：
 
 ```
 //! - `tail(path, options)` - Follow a file like `tail -F`, returning a line iterator that
 //!   yields new lines as they are appended. Automatically follows file rotations.
 ```
 
-## Testing
+## 測試
 
-All tests in `src/bindings/fs.rs` `mod tests`, using `tempfile` for test fixtures:
+所有測試位於 `src/bindings/fs.rs` 的 `mod tests` 中，使用 `tempfile` 建立測試檔案：
 
-1. **Basic read** — Write lines to a file, `tail` with `from = "start"`, verify all lines are yielded
-2. **Wait for new lines** — Tail an existing file (hits EOF), spawn a thread that writes new lines after a delay, verify the new lines are received
-3. **Rotation detection** — Tail a file, rename it, create a new file at the same path, write to the new file, verify tail follows the new file
-4. **File does not exist** — Tail a non-existent path, spawn a thread that creates the file after a delay, verify lines are received once the file appears
-5. **Break exits cleanly** — Tail a file, break after N lines, verify no panic or resource leak
-6. **Permission denied** — Tail a path without read permission, verify error is returned
+1. **基本讀取** — 寫入行到檔案，以 `from = "start"` 呼叫 `tail`，驗證所有行都被產出
+2. **等待新行** — tail 一個既有檔案（到達 EOF），從另一個 thread 延遲寫入新行，驗證能收到新行
+3. **輪替偵測** — tail 一個檔案，重新命名它，在同路徑建立新檔案並寫入，驗證 tail 跟隨新檔案
+4. **檔案不存在** — tail 一個不存在的路徑，從另一個 thread 延遲建立檔案，驗證檔案出現後能收到行
+5. **break 正常離開** — tail 一個檔案，在 N 行後 break，驗證無 panic 或資源洩漏
+6. **權限不足** — 在沒有讀取權限的情況下 tail，驗證回傳錯誤
 
-## Configuration Reference
+## 設定參考
 
-No new CLI flags or environment variables. Configuration is per-call via the options table.
+無新增 CLI 旗標或環境變數。設定透過 options table 逐次呼叫指定。

--- a/docs/superpowers/specs/2026-03-17-fs-tail-design.md
+++ b/docs/superpowers/specs/2026-03-17-fs-tail-design.md
@@ -47,7 +47,7 @@ Returns a Lua iterator function for use in `for...in` loops. The iterator yields
 | File does not exist yet | Wait (polling) until the file appears, then start reading |
 | File temporarily missing (rotate gap) | Keep waiting, resume when file reappears |
 | `break` in for loop | Exit loop normally. The `TailState` (including open `File` handle) is held by `Arc<Mutex<...>>` inside the closure; it is released when the closure is garbage-collected. This is non-deterministic but safe — consistent with how `fs.lines()` handles its file handle. |
-| Permission denied | Check the **parent directory** for read permission at call time (before iterator starts). The file itself may not exist yet, so we cannot canonicalize it. If the parent directory is not readable, return an error immediately. |
+| Permission denied | Call `check_read_permission(path)` at call time (before iterator starts). The existing `canonicalize_for_check` already handles non-existent files by canonicalizing the parent directory and appending the filename. |
 
 ## Rotation Detection
 
@@ -82,10 +82,9 @@ New method added to `FsBinding::add_methods` in `src/bindings/fs.rs`:
 
 ```rust
 methods.add_method("tail", |vm, this, (path, options): (String, Option<LuaTable>)| {
-    // Permission check: verify parent directory is readable (file may not exist yet)
-    let parent = Path::new(&path).parent().unwrap_or(Path::new("."));
-    this.check_read_permission(&parent.to_string_lossy())
-        .map_err(LuaError::runtime)?;
+    // Permission check: pass full file path. check_read_permission -> canonicalize_for_check
+    // already handles non-existent files by canonicalizing the parent dir and appending filename.
+    this.check_read_permission(&path).map_err(LuaError::runtime)?;
 
     let poll_interval = /* extract from options, default 100 */;
     let from_end = /* extract from options, default true */;
@@ -124,7 +123,9 @@ methods.add_method("tail", |vm, this, (path, options): (String, Option<LuaTable>
 });
 ```
 
-**Important:** The `Mutex` lock is released before the `.await` point to avoid holding it across the async sleep. This prevents deadlocks and allows other Lua coroutines to make progress.
+**Important:**
+- The `parking_lot::Mutex` lock (consistent with the rest of `fs.rs`) is released before the `.await` point to avoid holding it across the async sleep. This prevents deadlocks and allows other Lua coroutines to make progress.
+- `fs.tail()` requires the Lua script to be executed via `call_async` (the normal execution path in LMB). The async iterator function will panic if called from a synchronous Lua context. This is the same precondition that applies to `io.read` and other async bindings in LMB.
 
 ### `TailState` Struct
 
@@ -148,7 +149,7 @@ struct TailState {
 
 | Aspect | Approach |
 |--------|----------|
-| **Permission check** | Checks **parent directory** read permission at call time (file may not exist yet). Uses existing `check_read_permission()`. |
+| **Permission check** | Reuses `check_read_permission(path)` at call time. `canonicalize_for_check` already handles non-existent files by canonicalizing the parent and appending the filename. |
 | **Method registration** | `add_method("tail", ...)` returns an async closure via `vm.create_async_function`, alongside existing methods in `FsBinding::add_methods` |
 | **Line trimming** | Strips trailing `\n` and `\r`, consistent with `fs.lines()` and `FileHandleBinding::read("*l")` |
 | **Error handling** | IO errors during read are reported via `LuaError`, consistent with other fs methods |

--- a/src/bindings/fs.rs
+++ b/src/bindings/fs.rs
@@ -1679,4 +1679,19 @@ mod tests {
         let result = runner.invoke().state(state).call().await.expect("invoke");
         assert_eq!(json!(["a", "b"]), result.result.expect("result"));
     }
+
+    #[tokio::test]
+    async fn test_tail_permission_denied() {
+        let tmp = NamedTempFile::new().expect("create temp file");
+        let path = tmp.path().to_string_lossy().to_string();
+
+        let source = include_str!("../fixtures/bindings/fs/tail-permission-denied.lua");
+        // No permissions granted
+        let runner = Runner::builder(source, empty())
+            .build()
+            .expect("build runner");
+        let state = State::builder().state(json!(path)).build();
+        let result = runner.invoke().state(state).call().await.expect("invoke");
+        assert_eq!(json!(true), result.result.expect("result"));
+    }
 }

--- a/src/bindings/fs.rs
+++ b/src/bindings/fs.rs
@@ -608,25 +608,22 @@ impl LuaUserData for FsBinding {
                 from_end,
             )));
 
-            vm.create_async_function(move |vm, ()| {
-                let state = state.clone();
-                async move {
-                    loop {
-                        let (result, poll_ms) = {
-                            let mut st = state.lock();
-                            st.check_rotation();
-                            st.ensure_open();
-                            (st.read_line(), st.poll_interval)
-                        };
-                        // Lock released before await
-
-                        match result {
-                            Some(line) => return vm.create_string(&line).map(LuaValue::String),
-                            None => {
-                                tokio::time::sleep(Duration::from_millis(poll_ms)).await;
-                            }
-                        }
+            // Use sync closure (not async) because Luau's `for...in` loop
+            // calls the iterator via a C-call boundary that does not allow yields.
+            // std::thread::sleep blocks the current tokio worker thread, which is
+            // acceptable: a tail script is expected to be long-running and already
+            // monopolizes one worker thread for the Lua VM's lifetime.
+            vm.create_function(move |vm, ()| {
+                loop {
+                    let mut st = state.lock();
+                    st.check_rotation();
+                    st.ensure_open();
+                    if let Some(line) = st.read_line() {
+                        return vm.create_string(&line).map(LuaValue::String);
                     }
+                    let poll_ms = st.poll_interval;
+                    drop(st);
+                    std::thread::sleep(Duration::from_millis(poll_ms));
                 }
             })
         });
@@ -636,6 +633,9 @@ impl LuaUserData for FsBinding {
 #[cfg(test)]
 mod tests {
     use std::io::Write as _;
+
+    use std::fs::{File, OpenOptions};
+    use std::time::Duration;
 
     use serde_json::json;
     use tempfile::{NamedTempFile, TempDir};
@@ -1693,5 +1693,54 @@ mod tests {
         let state = State::builder().state(json!(path)).build();
         let result = runner.invoke().state(state).call().await.expect("invoke");
         assert_eq!(json!(true), result.result.expect("result"));
+    }
+
+    #[tokio::test]
+    async fn test_tail_wait_new_lines() {
+        let mut tmp = NamedTempFile::new().expect("create temp file");
+        write!(tmp, "first\n").expect("write temp file");
+        let path = tmp.path().to_string_lossy().to_string();
+        let dir = tmp.path().parent().expect("parent dir").to_path_buf();
+
+        let source = include_str!("../fixtures/bindings/fs/tail-wait-new-lines.lua");
+        let perm = fs_permissions(
+            ReadPermissions::Some {
+                allowed: [dir].into_iter().collect(),
+                denied: Default::default(),
+            },
+            WritePermissions::Some {
+                allowed: Default::default(),
+                denied: Default::default(),
+            },
+        );
+        let runner = Runner::builder(source, empty())
+            .permissions(perm)
+            .build()
+            .expect("build runner");
+
+        let write_path = tmp.path().to_path_buf();
+        // Use OS thread (not tokio::spawn) because the tail iterator uses
+        // std::thread::sleep which blocks the tokio worker thread.
+        let writer = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(200));
+            let mut f = OpenOptions::new()
+                .append(true)
+                .open(&write_path)
+                .expect("open for append");
+            writeln!(f, "second").expect("write second");
+            writeln!(f, "third").expect("write third");
+        });
+
+        let state = State::builder()
+            .state(json!({"path": path, "expected": 3}))
+            .build();
+
+        let result = runner.invoke().state(state).call().await.expect("invoke");
+
+        writer.join().expect("writer thread");
+        assert_eq!(
+            json!(["first", "second", "third"]),
+            result.result.expect("result")
+        );
     }
 }

--- a/src/bindings/fs.rs
+++ b/src/bindings/fs.rs
@@ -176,10 +176,7 @@ impl TailState {
             Ok(0) => None, // EOF
             Ok(n) => {
                 self.position += n as u64;
-                let trimmed = self
-                    .line_buf
-                    .trim_end_matches('\n')
-                    .trim_end_matches('\r');
+                let trimmed = self.line_buf.trim_end_matches('\n').trim_end_matches('\r');
                 Some(trimmed.to_string())
             }
             Err(_) => {
@@ -581,47 +578,46 @@ impl LuaUserData for FsBinding {
             Ok(table)
         });
 
-        methods.add_method("tail", |vm, this, (path, options): (String, Option<LuaTable>)| {
-            this.check_read_permission(&path)
-                .map_err(LuaError::runtime)?;
+        methods.add_method(
+            "tail",
+            |vm, this, (path, options): (String, Option<LuaTable>)| {
+                this.check_read_permission(&path)
+                    .map_err(LuaError::runtime)?;
 
-            let poll_interval = match &options {
-                Some(t) => t.get::<u64>("poll_interval").unwrap_or(100),
-                None => 100,
-            };
-            let from_end = match &options {
-                Some(t) => {
-                    let from: Option<String> = t.get("from").ok();
-                    !matches!(from.as_deref(), Some("start"))
-                }
-                None => true,
-            };
-
-            let state = Arc::new(Mutex::new(TailState::new(
-                path,
-                poll_interval,
-                from_end,
-            )));
-
-            // Use sync closure (not async) because Luau's `for...in` loop
-            // calls the iterator via a C-call boundary that does not allow yields.
-            // std::thread::sleep blocks the current tokio worker thread, which is
-            // acceptable: a tail script is expected to be long-running and already
-            // monopolizes one worker thread for the Lua VM's lifetime.
-            vm.create_function(move |vm, ()| {
-                loop {
-                    let mut st = state.lock();
-                    st.check_rotation();
-                    st.ensure_open();
-                    if let Some(line) = st.read_line() {
-                        return vm.create_string(&line).map(LuaValue::String);
+                let poll_interval = match &options {
+                    Some(t) => t.get::<u64>("poll_interval").unwrap_or(100),
+                    None => 100,
+                };
+                let from_end = match &options {
+                    Some(t) => {
+                        let from: Option<String> = t.get("from").ok();
+                        !matches!(from.as_deref(), Some("start"))
                     }
-                    let poll_ms = st.poll_interval;
-                    drop(st);
-                    std::thread::sleep(Duration::from_millis(poll_ms));
-                }
-            })
-        });
+                    None => true,
+                };
+
+                let state = Arc::new(Mutex::new(TailState::new(path, poll_interval, from_end)));
+
+                // Use sync closure (not async) because Luau's `for...in` loop
+                // calls the iterator via a C-call boundary that does not allow yields.
+                // std::thread::sleep blocks the current tokio worker thread, which is
+                // acceptable: a tail script is expected to be long-running and already
+                // monopolizes one worker thread for the Lua VM's lifetime.
+                vm.create_function(move |vm, ()| {
+                    loop {
+                        let mut st = state.lock();
+                        st.check_rotation();
+                        st.ensure_open();
+                        if let Some(line) = st.read_line() {
+                            return vm.create_string(&line).map(LuaValue::String);
+                        }
+                        let poll_ms = st.poll_interval;
+                        drop(st);
+                        std::thread::sleep(Duration::from_millis(poll_ms));
+                    }
+                })
+            },
+        );
     }
 }
 

--- a/src/bindings/fs.rs
+++ b/src/bindings/fs.rs
@@ -149,21 +149,16 @@ impl TailState {
         if self.reader.is_none() {
             return;
         }
-        let metadata = match std::fs::metadata(&self.path) {
-            Ok(m) => m,
-            Err(_) => {
-                // File gone — close reader, enter waiting mode
-                self.reader = None;
-                return;
-            }
+        let Ok(metadata) = std::fs::metadata(&self.path) else {
+            // File gone — close reader, enter waiting mode
+            self.reader = None;
+            return;
         };
 
         #[cfg(unix)]
-        if let Some(prev_inode) = self.inode {
-            if metadata.ino() != prev_inode {
-                self.reader = None;
-                return;
-            }
+        if self.inode.is_some_and(|prev| metadata.ino() != prev) {
+            self.reader = None;
+            return;
         }
 
         if metadata.len() < self.position {
@@ -1698,7 +1693,7 @@ mod tests {
     #[tokio::test]
     async fn test_tail_wait_new_lines() {
         let mut tmp = NamedTempFile::new().expect("create temp file");
-        write!(tmp, "first\n").expect("write temp file");
+        writeln!(tmp, "first").expect("write temp file");
         let path = tmp.path().to_string_lossy().to_string();
         let dir = tmp.path().parent().expect("parent dir").to_path_buf();
 

--- a/src/bindings/fs.rs
+++ b/src/bindings/fs.rs
@@ -1743,4 +1743,56 @@ mod tests {
             result.result.expect("result")
         );
     }
+
+    #[tokio::test]
+    async fn test_tail_rotation() {
+        let dir = TempDir::new().expect("create temp dir");
+        let file_path = dir.path().join("test.log");
+        {
+            let mut f = File::create(&file_path).expect("create file");
+            writeln!(f, "old1").expect("write");
+            writeln!(f, "old2").expect("write");
+        }
+        let path_str = file_path.to_string_lossy().to_string();
+        let dir_path = dir.path().to_path_buf();
+
+        let source = include_str!("../fixtures/bindings/fs/tail-rotation.lua");
+        let perm = fs_permissions(
+            ReadPermissions::Some {
+                allowed: [dir_path].into_iter().collect(),
+                denied: Default::default(),
+            },
+            WritePermissions::Some {
+                allowed: Default::default(),
+                denied: Default::default(),
+            },
+        );
+        let runner = Runner::builder(source, empty())
+            .permissions(perm)
+            .build()
+            .expect("build runner");
+
+        let rotate_path = file_path.clone();
+        let rotator = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(300));
+            let rotated = rotate_path.with_extension("log.1");
+            std::fs::rename(&rotate_path, &rotated).expect("rename");
+            std::thread::sleep(Duration::from_millis(100));
+            let mut f = File::create(&rotate_path).expect("create new file");
+            writeln!(f, "new1").expect("write new");
+            writeln!(f, "new2").expect("write new");
+        });
+
+        let state = State::builder()
+            .state(json!({"path": path_str, "expected": 4}))
+            .build();
+
+        let result = runner.invoke().state(state).call().await.expect("invoke");
+
+        rotator.join().expect("rotator thread");
+        assert_eq!(
+            json!(["old1", "old2", "new1", "new2"]),
+            result.result.expect("result")
+        );
+    }
 }

--- a/src/bindings/fs.rs
+++ b/src/bindings/fs.rs
@@ -1795,4 +1795,48 @@ mod tests {
             result.result.expect("result")
         );
     }
+
+    #[tokio::test]
+    async fn test_tail_file_not_exists() {
+        let dir = TempDir::new().expect("create temp dir");
+        let file_path = dir.path().join("future.log");
+        let path_str = file_path.to_string_lossy().to_string();
+        let dir_path = dir.path().to_path_buf();
+
+        let source = include_str!("../fixtures/bindings/fs/tail-file-not-exists.lua");
+        let perm = fs_permissions(
+            ReadPermissions::Some {
+                allowed: [dir_path].into_iter().collect(),
+                denied: Default::default(),
+            },
+            WritePermissions::Some {
+                allowed: Default::default(),
+                denied: Default::default(),
+            },
+        );
+        let runner = Runner::builder(source, empty())
+            .permissions(perm)
+            .build()
+            .expect("build runner");
+
+        let create_path = file_path.clone();
+        let creator = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(300));
+            let mut f = File::create(&create_path).expect("create file");
+            writeln!(f, "appeared1").expect("write");
+            writeln!(f, "appeared2").expect("write");
+        });
+
+        let state = State::builder()
+            .state(json!({"path": path_str, "expected": 2}))
+            .build();
+
+        let result = runner.invoke().state(state).call().await.expect("invoke");
+
+        creator.join().expect("creator thread");
+        assert_eq!(
+            json!(["appeared1", "appeared2"]),
+            result.result.expect("result")
+        );
+    }
 }

--- a/src/bindings/fs.rs
+++ b/src/bindings/fs.rs
@@ -1652,4 +1652,31 @@ mod tests {
             result.result.expect("result")
         );
     }
+
+    #[tokio::test]
+    async fn test_tail_break() {
+        let mut tmp = NamedTempFile::new().expect("create temp file");
+        write!(tmp, "a\nb\nc\nd\ne\n").expect("write temp file");
+        let path = tmp.path().to_string_lossy().to_string();
+        let dir = tmp.path().parent().expect("parent dir").to_path_buf();
+
+        let source = include_str!("../fixtures/bindings/fs/tail-break.lua");
+        let perm = fs_permissions(
+            ReadPermissions::Some {
+                allowed: [dir].into_iter().collect(),
+                denied: Default::default(),
+            },
+            WritePermissions::Some {
+                allowed: Default::default(),
+                denied: Default::default(),
+            },
+        );
+        let runner = Runner::builder(source, empty())
+            .permissions(perm)
+            .build()
+            .expect("build runner");
+        let state = State::builder().state(json!(path)).build();
+        let result = runner.invoke().state(state).call().await.expect("invoke");
+        assert_eq!(json!(["a", "b"]), result.result.expect("result"));
+    }
 }

--- a/src/bindings/fs.rs
+++ b/src/bindings/fs.rs
@@ -71,13 +71,127 @@ use std::{
     io::{BufRead, BufReader, Read, Seek, SeekFrom, Write},
     path::{Path, PathBuf},
     sync::Arc,
+    time::Duration,
 };
+
+#[cfg(unix)]
+use std::os::unix::fs::MetadataExt;
 
 use bon::bon;
 use mlua::prelude::*;
 use parking_lot::Mutex;
 
 use crate::Permissions;
+
+/// Internal state for the `fs.tail()` iterator.
+/// Tracks file position, inode, and handles rotation detection.
+struct TailState {
+    path: PathBuf,
+    reader: Option<BufReader<File>>,
+    inode: Option<u64>,
+    position: u64,
+    poll_interval: u64,
+    from_end: bool,
+    line_buf: String,
+}
+
+impl TailState {
+    fn new(path: String, poll_interval: u64, from_end: bool) -> Self {
+        Self {
+            path: PathBuf::from(path),
+            reader: None,
+            inode: None,
+            position: 0,
+            poll_interval,
+            from_end,
+            line_buf: String::new(),
+        }
+    }
+
+    /// Try to open the file. If `from_end` is true on first open, seek to end.
+    /// Returns true if file is now open, false if file doesn't exist.
+    fn ensure_open(&mut self) -> bool {
+        if self.reader.is_some() {
+            return true;
+        }
+        let file = match File::open(&self.path) {
+            Ok(f) => f,
+            Err(_) => return false,
+        };
+        let metadata = match file.metadata() {
+            Ok(m) => m,
+            Err(_) => return false,
+        };
+        #[cfg(unix)]
+        let inode = Some(metadata.ino());
+        #[cfg(not(unix))]
+        let inode = None;
+
+        let mut reader = BufReader::new(file);
+        if self.from_end && self.inode.is_none() {
+            // First open with from_end: seek to end
+            let end = reader.seek(SeekFrom::End(0)).unwrap_or(0);
+            self.position = end;
+        } else if self.inode.is_some() {
+            // Reopened after rotation: read from beginning
+            self.position = 0;
+        }
+        self.inode = inode;
+        self.reader = Some(reader);
+        true
+    }
+
+    /// Check if the file has been rotated (inode change or size shrink).
+    /// If so, close current reader so `ensure_open` will reopen.
+    fn check_rotation(&mut self) {
+        if self.reader.is_none() {
+            return;
+        }
+        let metadata = match std::fs::metadata(&self.path) {
+            Ok(m) => m,
+            Err(_) => {
+                // File gone — close reader, enter waiting mode
+                self.reader = None;
+                return;
+            }
+        };
+
+        #[cfg(unix)]
+        if let Some(prev_inode) = self.inode {
+            if metadata.ino() != prev_inode {
+                self.reader = None;
+                return;
+            }
+        }
+
+        if metadata.len() < self.position {
+            // File truncated — close and reopen
+            self.reader = None;
+        }
+    }
+
+    /// Try to read one line. Returns Some(line) with trailing newline stripped,
+    /// or None if at EOF or file not open.
+    fn read_line(&mut self) -> Option<String> {
+        let reader = self.reader.as_mut()?;
+        self.line_buf.clear();
+        match reader.read_line(&mut self.line_buf) {
+            Ok(0) => None, // EOF
+            Ok(n) => {
+                self.position += n as u64;
+                let trimmed = self
+                    .line_buf
+                    .trim_end_matches('\n')
+                    .trim_end_matches('\r');
+                Some(trimmed.to_string())
+            }
+            Err(_) => {
+                self.reader = None;
+                None
+            }
+        }
+    }
+}
 
 /// A file handle wrapping a buffered reader/writer.
 ///

--- a/src/bindings/fs.rs
+++ b/src/bindings/fs.rs
@@ -16,6 +16,8 @@
 //! - `rename(old, new)` - Rename a file.
 //! - `exists(path)` - Check if a path exists.
 //! - `list(path)` - List directory contents, returning a table of filenames.
+//! - `tail(path, options)` - Follow a file like `tail -F`, returning a line iterator that
+//!   yields new lines as they are appended. Automatically follows file rotations.
 //!
 //! # File Handle Methods
 //!
@@ -582,6 +584,51 @@ impl LuaUserData for FsBinding {
                 i += 1;
             }
             Ok(table)
+        });
+
+        methods.add_method("tail", |vm, this, (path, options): (String, Option<LuaTable>)| {
+            this.check_read_permission(&path)
+                .map_err(LuaError::runtime)?;
+
+            let poll_interval = match &options {
+                Some(t) => t.get::<u64>("poll_interval").unwrap_or(100),
+                None => 100,
+            };
+            let from_end = match &options {
+                Some(t) => {
+                    let from: Option<String> = t.get("from").ok();
+                    !matches!(from.as_deref(), Some("start"))
+                }
+                None => true,
+            };
+
+            let state = Arc::new(Mutex::new(TailState::new(
+                path,
+                poll_interval,
+                from_end,
+            )));
+
+            vm.create_async_function(move |vm, ()| {
+                let state = state.clone();
+                async move {
+                    loop {
+                        let (result, poll_ms) = {
+                            let mut st = state.lock();
+                            st.check_rotation();
+                            st.ensure_open();
+                            (st.read_line(), st.poll_interval)
+                        };
+                        // Lock released before await
+
+                        match result {
+                            Some(line) => return vm.create_string(&line).map(LuaValue::String),
+                            None => {
+                                tokio::time::sleep(Duration::from_millis(poll_ms)).await;
+                            }
+                        }
+                    }
+                }
+            })
         });
     }
 }

--- a/src/bindings/fs.rs
+++ b/src/bindings/fs.rs
@@ -1622,4 +1622,34 @@ mod tests {
                 .contains("read permission denied")
         );
     }
+
+    #[tokio::test]
+    async fn test_tail_basic() {
+        let mut tmp = NamedTempFile::new().expect("create temp file");
+        write!(tmp, "line1\nline2\nline3\n").expect("write temp file");
+        let path = tmp.path().to_string_lossy().to_string();
+        let dir = tmp.path().parent().expect("parent dir").to_path_buf();
+
+        let source = include_str!("../fixtures/bindings/fs/tail-basic.lua");
+        let perm = fs_permissions(
+            ReadPermissions::Some {
+                allowed: [dir].into_iter().collect(),
+                denied: Default::default(),
+            },
+            WritePermissions::Some {
+                allowed: Default::default(),
+                denied: Default::default(),
+            },
+        );
+        let runner = Runner::builder(source, empty())
+            .permissions(perm)
+            .build()
+            .expect("build runner");
+        let state = State::builder().state(json!(path)).build();
+        let result = runner.invoke().state(state).call().await.expect("invoke");
+        assert_eq!(
+            json!(["line1", "line2", "line3"]),
+            result.result.expect("result")
+        );
+    }
 }

--- a/src/fixtures/bindings/fs/tail-basic.lua
+++ b/src/fixtures/bindings/fs/tail-basic.lua
@@ -1,0 +1,13 @@
+function tail_basic(ctx)
+  local fs = require("@lmb/fs")
+  local result = {}
+  for line in fs:tail(ctx.state, { from = "start" }) do
+    table.insert(result, line)
+    if #result >= 3 then
+      break
+    end
+  end
+  return result
+end
+
+return tail_basic

--- a/src/fixtures/bindings/fs/tail-break.lua
+++ b/src/fixtures/bindings/fs/tail-break.lua
@@ -1,0 +1,13 @@
+function tail_break(ctx)
+  local fs = require("@lmb/fs")
+  local result = {}
+  for line in fs:tail(ctx.state, { from = "start" }) do
+    table.insert(result, line)
+    if #result >= 2 then
+      break
+    end
+  end
+  return result
+end
+
+return tail_break

--- a/src/fixtures/bindings/fs/tail-file-not-exists.lua
+++ b/src/fixtures/bindings/fs/tail-file-not-exists.lua
@@ -1,0 +1,13 @@
+function tail_not_exists(ctx)
+  local fs = require("@lmb/fs")
+  local result = {}
+  for line in fs:tail(ctx.state.path, { from = "start", poll_interval = 50 }) do
+    table.insert(result, line)
+    if #result >= ctx.state.expected then
+      break
+    end
+  end
+  return result
+end
+
+return tail_not_exists

--- a/src/fixtures/bindings/fs/tail-permission-denied.lua
+++ b/src/fixtures/bindings/fs/tail-permission-denied.lua
@@ -1,0 +1,14 @@
+function tail_permission_denied(ctx)
+  local fs = require("@lmb/fs")
+  local ok, err = pcall(function()
+    for line in fs:tail(ctx.state) do
+      -- should never reach here
+    end
+  end)
+  assert(not ok, "Expected error")
+  local err_str = tostring(err)
+  assert(string.find(err_str, "permission denied"), "Expected 'permission denied' in error: " .. err_str)
+  return true
+end
+
+return tail_permission_denied

--- a/src/fixtures/bindings/fs/tail-rotation.lua
+++ b/src/fixtures/bindings/fs/tail-rotation.lua
@@ -1,0 +1,13 @@
+function tail_rotation(ctx)
+  local fs = require("@lmb/fs")
+  local result = {}
+  for line in fs:tail(ctx.state.path, { from = "start", poll_interval = 50 }) do
+    table.insert(result, line)
+    if #result >= ctx.state.expected then
+      break
+    end
+  end
+  return result
+end
+
+return tail_rotation

--- a/src/fixtures/bindings/fs/tail-wait-new-lines.lua
+++ b/src/fixtures/bindings/fs/tail-wait-new-lines.lua
@@ -1,0 +1,14 @@
+function tail_wait(ctx)
+  local fs = require("@lmb/fs")
+  local result = {}
+  -- ctx.state is { path = "...", expected = N }
+  for line in fs:tail(ctx.state.path, { from = "start", poll_interval = 50 }) do
+    table.insert(result, line)
+    if #result >= ctx.state.expected then
+      break
+    end
+  end
+  return result
+end
+
+return tail_wait


### PR DESCRIPTION
## Summary

- Add `fs.tail(path, options?)` method that follows a file like `tail -F`, yielding new lines via a Lua iterator
- Automatic rotation detection (inode change / file truncation) for logrotate compatibility
- Polling-based with configurable interval (default 100ms), no new dependencies
- Options: `poll_interval` (ms) and `from` ("end" or "start")

## Test Plan

- [x] Basic read — tail with `from = "start"`, collect all lines
- [x] Break exits cleanly — break after N lines
- [x] Permission denied — tail without read permission
- [x] Wait for new lines — tail waits and reads lines appended after start
- [x] Rotation detection — rename old file, create new file at same path, verify tail follows
- [x] File does not exist — tail non-existent path, create file later, verify lines received
- [x] All 317 tests pass, clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)