### PR TITLE
fix(deps): bump rustls-webpki to 0.103.12 for RUSTSEC-2026-0099

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3159,9 +3159,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary
- Bumps `rustls-webpki` from 0.103.10 → 0.103.12 (via `Cargo.lock`) to close [RUSTSEC-2026-0099](https://rustsec.org/advisories/RUSTSEC-2026-0099) (wildcard name-constraint bypass, GHSA-xgp8-3hg3-c2mh).
- Unblocks CI `lint` on open dependency PRs (#222, #223), which currently fail the `cargo-deny advisories` check for this exact advisory.

## Test plan
- [x] `cargo deny check advisories` locally — `advisories ok`
- [ ] CI `lint`, `check`, `msrv`, `coverage`, `bench` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)