### PR TITLE
fix(docker): install cross-compile target against pinned toolchain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,13 @@ FROM chef AS builder
 ARG TARGETPLATFORM
 ARG GIT_VERSION=dev
 
+# Copy the toolchain pin BEFORE any rustup invocation so that rustup resolves
+# against the pinned toolchain (rust-toolchain.toml) rather than whatever patch
+# version the base image happens to ship. Without this the base image's default
+# toolchain gets the cross-compile target installed, and then `cargo build`
+# downloads the pinned toolchain fresh (without the target) and fails.
+COPY rust-toolchain.toml .
+
 # Install cross-compilation toolchain based on target
 RUN case "$TARGETPLATFORM" in \
         "linux/arm64") \


### PR DESCRIPTION
## Summary
- Copy `rust-toolchain.toml` into the builder stage before `rustup target add` so the aarch64 target is installed against the pinned 1.94.0 toolchain, not the base image default.
- Fixes the ARM64 Docker build failure on `main` (`E0463: can't find crate for core` when compiling `memchr`).

## Why it broke
`rust-toolchain.toml` pins the channel to 1.94.0. Without the toolchain file present at `rustup target add` time, rustup installs the aarch64 target against whatever default the `rust:1.94-bookworm` image ships. `cargo build` later reads the pinned file, downloads 1.94.0 fresh (without the target), and fails.

Mirrors the fix applied in [rdrs#149](https://github.com/henry40408/rdrs/pull/149).

## Test plan
- [ ] CI `Docker` workflow passes for `linux/amd64` and `linux/arm64`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)