### PR TITLE
chore(deps): bump aes/cbc/des/ecb to cipher v0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,13 +19,13 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aes"
-version = "0.8.4"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+checksum = "66bd29a732b644c0431c6140f370d097879203d79b80c94a6747ba0872adaef8"
 dependencies = [
- "cfg-if",
  "cipher",
- "cpufeatures 0.2.17",
+ "cpubits",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -345,11 +345,11 @@ dependencies = [
 
 [[package]]
 name = "block-padding"
-version = "0.3.3"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -482,9 +482,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cbc"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+checksum = "98db6aeaef0eeef2c1e3ce9a27b739218825dae116076352ac3777076aa22225"
 dependencies = [
  "cipher",
 ]
@@ -566,11 +566,11 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.4.4"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+checksum = "e34d8227fe1ba289043aeb13792056ff80fd6de1a9f49137a5f499de8e8c78ea"
 dependencies = [
- "crypto-common 0.1.7",
+ "crypto-common 0.2.1",
  "inout",
 ]
 
@@ -681,6 +681,12 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpubits"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef0c543070d296ea414df2dd7625d1b24866ce206709d8a4a424f28377f5861"
 
 [[package]]
 name = "cpufeatures"
@@ -904,9 +910,9 @@ dependencies = [
 
 [[package]]
 name = "des"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdd80ce8ce993de27e9f063a444a4d53ce8e8db4c1f00cc03af5ad5a9867a1e"
+checksum = "916a94e407b54f9034d71dd748234cd1e516ced6284009906ae246f177eafe5a"
 dependencies = [
  "cipher",
 ]
@@ -959,9 +965,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecb"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a8bfa975b1aec2145850fcaa1c6fe269a16578c44705a532ae3edc92b8881c7"
+checksum = "fbfbf3db731928d6912bc3beda911d55b834cee3df6131ba79b337a1298a3fa9"
 dependencies = [
  "cipher",
 ]
@@ -1694,12 +1700,12 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.1.4"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
  "block-padding",
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ default = []
 postgres = ["dep:postgres"]
 
 [dependencies]
-aes = "0.8.4"
+aes = "0.9.0"
 anyhow = "1.0.101"
 axum = "0.8.9"
 base16ct = { version = "1.0.0", features = ["alloc"] }
@@ -18,13 +18,13 @@ base64 = "0.22.1"
 bon = "3.9.0"
 byte-unit = "5.1.6"
 bytes = "1.10.1"
-cbc = { version = "0.1.2", features = ["alloc"] }
+cbc = { version = "0.2.0", features = ["alloc"] }
 clap = { version = "4.5.58", features = ["derive", "env"] }
 clio = { version = "0.3.5", features = ["clap-parse"] }
 crc32fast = "1.5.0"
 deadpool = "0.13.0"
-des = "0.8.1"
-ecb = "0.1.2"
+des = "0.9.0"
+ecb = "0.2.0"
 futures = "0.3.31"
 hex = "0.4.3"
 hmac = "0.13.0"

--- a/src/bindings/crypto.rs
+++ b/src/bindings/crypto.rs
@@ -61,8 +61,8 @@
 use std::{fmt, sync::Arc};
 
 use aes::cipher::{
-    BlockDecryptMut as _, BlockEncryptMut as _, KeyInit as AesKeyInit, KeyIvInit as _,
-    block_padding::Pkcs7,
+    BlockModeDecrypt as _, BlockModeEncrypt as _, KeyInit as AesKeyInit, KeyIvInit as _,
+    block_padding::{Error as UnpadError, Pkcs7},
 };
 use base64::prelude::*;
 use hmac::{Hmac, KeyInit, Mac};
@@ -135,19 +135,34 @@ impl LuaUserData for CryptoBinding {
             {
                 "aes-cbc" => {
                     let iv = iv.ok_or_else(|| bad_argument("encrypt", 4, "expect IV"))?;
-                    let encrypted = Aes128CbcEnc::new(key.as_bytes().into(), iv.as_bytes().into())
-                        .encrypt_padded_vec_mut::<Pkcs7>(data.as_bytes());
+                    let Ok(key) = <&[u8; 16]>::try_from(key.as_bytes()) else {
+                        return Err(bad_argument("encrypt", 3, "AES-128 key must be 16 bytes"));
+                    };
+                    let Ok(iv) = <&[u8; 16]>::try_from(iv.as_bytes()) else {
+                        return Err(bad_argument("encrypt", 4, "AES-128 IV must be 16 bytes"));
+                    };
+                    let encrypted = Aes128CbcEnc::new(key.into(), iv.into())
+                        .encrypt_padded_vec::<Pkcs7>(data.as_bytes());
                     Ok(base16ct::lower::encode_string(&encrypted))
                 }
                 "des-cbc" => {
                     let iv = iv.ok_or_else(|| bad_argument("encrypt", 4, "expect IV"))?;
-                    let encrypted = DesCbcEnc::new(key.as_bytes().into(), iv.as_bytes().into())
-                        .encrypt_padded_vec_mut::<Pkcs7>(data.as_bytes());
+                    let Ok(key) = <&[u8; 8]>::try_from(key.as_bytes()) else {
+                        return Err(bad_argument("encrypt", 3, "DES key must be 8 bytes"));
+                    };
+                    let Ok(iv) = <&[u8; 8]>::try_from(iv.as_bytes()) else {
+                        return Err(bad_argument("encrypt", 4, "DES IV must be 8 bytes"));
+                    };
+                    let encrypted = DesCbcEnc::new(key.into(), iv.into())
+                        .encrypt_padded_vec::<Pkcs7>(data.as_bytes());
                     Ok(base16ct::lower::encode_string(&encrypted))
                 }
                 "des-ecb" => {
-                    let encrypted = DesEcbEnc::new(key.as_bytes().into())
-                        .encrypt_padded_vec_mut::<Pkcs7>(data.as_bytes());
+                    let Ok(key) = <&[u8; 8]>::try_from(key.as_bytes()) else {
+                        return Err(bad_argument("encrypt", 3, "DES key must be 8 bytes"));
+                    };
+                    let encrypted =
+                        DesEcbEnc::new(key.into()).encrypt_padded_vec::<Pkcs7>(data.as_bytes());
                     Ok(base16ct::lower::encode_string(&encrypted))
                 }
                 _ => Err(bad_argument(
@@ -164,25 +179,40 @@ impl LuaUserData for CryptoBinding {
             {
                 "aes-cbc" => {
                     let iv = iv.ok_or_else(|| bad_argument("decrypt", 4, "expect IV"))?;
+                    let Ok(key) = <&[u8; 16]>::try_from(key.as_bytes()) else {
+                        return Err(bad_argument("decrypt", 3, "AES-128 key must be 16 bytes"));
+                    };
+                    let Ok(iv) = <&[u8; 16]>::try_from(iv.as_bytes()) else {
+                        return Err(bad_argument("decrypt", 4, "AES-128 IV must be 16 bytes"));
+                    };
                     let data = hex::decode(&encrypted).into_lua_err()?;
-                    let decrypted = Aes128CbcDec::new(key.as_bytes().into(), iv.as_bytes().into())
-                        .decrypt_padded_vec_mut::<Pkcs7>(&data)
-                        .map_err(|e| LuaError::external(e.to_string()))?;
+                    let decrypted = Aes128CbcDec::new(key.into(), iv.into())
+                        .decrypt_padded_vec::<Pkcs7>(&data)
+                        .map_err(|e: UnpadError| LuaError::external(e.to_string()))?;
                     Ok(String::from_utf8(decrypted).into_lua_err()?)
                 }
                 "des-cbc" => {
                     let iv = iv.ok_or_else(|| bad_argument("decrypt", 4, "expect IV"))?;
+                    let Ok(key) = <&[u8; 8]>::try_from(key.as_bytes()) else {
+                        return Err(bad_argument("decrypt", 3, "DES key must be 8 bytes"));
+                    };
+                    let Ok(iv) = <&[u8; 8]>::try_from(iv.as_bytes()) else {
+                        return Err(bad_argument("decrypt", 4, "DES IV must be 8 bytes"));
+                    };
                     let data = hex::decode(&encrypted).into_lua_err()?;
-                    let decrypted = DesCbcDec::new(key.as_bytes().into(), iv.as_bytes().into())
-                        .decrypt_padded_vec_mut::<Pkcs7>(&data)
-                        .map_err(|e| LuaError::external(e.to_string()))?;
+                    let decrypted = DesCbcDec::new(key.into(), iv.into())
+                        .decrypt_padded_vec::<Pkcs7>(&data)
+                        .map_err(|e: UnpadError| LuaError::external(e.to_string()))?;
                     Ok(String::from_utf8(decrypted).into_lua_err()?)
                 }
                 "des-ecb" => {
+                    let Ok(key) = <&[u8; 8]>::try_from(key.as_bytes()) else {
+                        return Err(bad_argument("decrypt", 3, "DES key must be 8 bytes"));
+                    };
                     let data = hex::decode(&encrypted).into_lua_err()?;
-                    let decrypted = DesEcbDec::new(key.as_bytes().into())
-                        .decrypt_padded_vec_mut::<Pkcs7>(&data)
-                        .map_err(|e| LuaError::external(e.to_string()))?;
+                    let decrypted = DesEcbDec::new(key.into())
+                        .decrypt_padded_vec::<Pkcs7>(&data)
+                        .map_err(|e: UnpadError| LuaError::external(e.to_string()))?;
                     Ok(String::from_utf8(decrypted).into_lua_err()?)
                 }
                 _ => Err(bad_argument(

--- a/src/fixtures/bindings/crypto-errors.lua
+++ b/src/fixtures/bindings/crypto-errors.lua
@@ -31,4 +31,60 @@ ok, err = pcall(function()
 end)
 assert(not ok, "Expected error for missing IV")
 
+-- Test wrong AES-128 key length
+ok, err = pcall(function()
+    crypto.encrypt("aes-cbc", "data", "shortkey", "abcdefghijklmnop")
+end)
+assert(not ok and string.find(tostring(err), "AES%-128 key"), "Expected error for wrong AES-128 key length")
+
+-- Test wrong AES-128 IV length
+ok, err = pcall(function()
+    crypto.encrypt("aes-cbc", "data", "1234567890123456", "shortiv")
+end)
+assert(not ok and string.find(tostring(err), "AES%-128 IV"), "Expected error for wrong AES-128 IV length")
+
+-- Test wrong DES key length (des-cbc)
+ok, err = pcall(function()
+    crypto.encrypt("des-cbc", "data", "short", "87654321")
+end)
+assert(not ok and string.find(tostring(err), "DES key"), "Expected error for wrong DES key length (des-cbc)")
+
+-- Test wrong DES IV length (des-cbc)
+ok, err = pcall(function()
+    crypto.encrypt("des-cbc", "data", "12345678", "short")
+end)
+assert(not ok and string.find(tostring(err), "DES IV"), "Expected error for wrong DES IV length (des-cbc)")
+
+-- Test wrong DES key length (des-ecb)
+ok, err = pcall(function()
+    crypto.encrypt("des-ecb", "data", "short")
+end)
+assert(not ok and string.find(tostring(err), "DES key"), "Expected error for wrong DES key length (des-ecb)")
+
+-- Test wrong key length in decrypt paths
+ok, err = pcall(function()
+    crypto.decrypt("aes-cbc", "00", "shortkey", "abcdefghijklmnop")
+end)
+assert(not ok and string.find(tostring(err), "AES%-128 key"), "Expected error for wrong AES-128 key length on decrypt")
+
+ok, err = pcall(function()
+    crypto.decrypt("aes-cbc", "00", "1234567890123456", "shortiv")
+end)
+assert(not ok and string.find(tostring(err), "AES%-128 IV"), "Expected error for wrong AES-128 IV length on decrypt")
+
+ok, err = pcall(function()
+    crypto.decrypt("des-cbc", "00", "short", "87654321")
+end)
+assert(not ok and string.find(tostring(err), "DES key"), "Expected error for wrong DES key length on decrypt (des-cbc)")
+
+ok, err = pcall(function()
+    crypto.decrypt("des-cbc", "00", "12345678", "short")
+end)
+assert(not ok and string.find(tostring(err), "DES IV"), "Expected error for wrong DES IV length on decrypt (des-cbc)")
+
+ok, err = pcall(function()
+    crypto.decrypt("des-ecb", "00", "short")
+end)
+assert(not ok and string.find(tostring(err), "DES key"), "Expected error for wrong DES key length on decrypt (des-ecb)")
+
 return true


### PR DESCRIPTION
## Summary

- Bumps `aes` (0.8.4 → 0.9.0), `cbc` (0.1.2 → 0.2.0), `des` (0.8.1 → 0.9.0), and `ecb` (0.1.2 → 0.2.0) in a single commit. These RustCrypto crates share the `cipher` v0.5 trait crate and cannot be upgraded independently — mixing them breaks trait bounds and yields duplicate `cipher` versions in `Cargo.lock`.
- Migrates `src/bindings/crypto.rs` to the cipher 0.5 API: `BlockDecryptMut`/`BlockEncryptMut` → `BlockModeDecrypt`/`BlockModeEncrypt`, dropped the `_mut` suffix on `encrypt_padded_vec`/`decrypt_padded_vec`, and replaced the old implicit `&[u8] → &Array` conversion with `<&[u8; N]>::try_from(...)` + a descriptive error message (the old API silently panicked on wrong key/IV length).
- Supersedes Dependabot PRs #228 (ecb), #229 (des), #231 (cbc), #232 (aes), which will auto-close once this merges.

## Test plan

- [x] `cargo check --all-targets` passes
- [x] `cargo nextest run` — 317/317 pass, incl. `bindings::crypto::tests::{test_crypto,test_crypto_errors,test_des_cbc_encryption,test_des_ecb_encryption}`
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-features` adds no new warnings on `src/bindings/crypto.rs`
- [ ] CI (all matrices) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)