### PR TITLE
fix(deps): bump rustls-webpki to 0.103.13 for RUSTSEC-2026-0104

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3159,9 +3159,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary

Bumps `rustls-webpki` from 0.103.12 to 0.103.13 to address [RUSTSEC-2026-0104](https://rustsec.org/advisories/RUSTSEC-2026-0104): a reachable panic when parsing certificate revocation lists whose `onlySomeReasons` extension contains an empty `BIT STRING`. Only `Cargo.lock` changes; no code changes.

This advisory dropped after #224's earlier bump to 0.103.12 and is currently failing `cargo deny` on `main` and on every open PR.

## Test plan

- [x] `cargo check` passes locally
- [ ] CI green (esp. the `cargo deny` step inside the `lint` job)

🤖 Generated with [Claude Code](https://claude.com/claude-code)