### PR TITLE
feat: add `@lmb/regex` module for regular expression support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1931,6 +1931,7 @@ dependencies = [
  "parking_lot",
  "postgres",
  "pulldown-cmark",
+ "regex",
  "reqwest",
  "rmp-serde",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ no_color = "0.2.0"
 parking_lot = "0.12.4"
 postgres = { version = "0.19", optional = true }
 pulldown-cmark = "0.13.3"
+regex = "1.12.3"
 reqwest = { version = "0.12.22", default-features = false, features = [
   "charset",
   "rustls-tls",

--- a/docs/guided-tour.md
+++ b/docs/guided-tour.md
@@ -809,6 +809,43 @@ end
 return time_example
 ```
 
+### Regex
+
+The `@lmb/regex` module provides full regular expression support backed by the Rust [`regex`](https://docs.rs/regex) crate. Luau's built-in `string.match`/`string.find`/`string.gmatch` only support Lua patterns, which lack features such as alternation, lookahead, and non-greedy quantifiers. The `regex` crate is fast and safe — it guarantees linear-time matching with no catastrophic backtracking. Invalid patterns raise an error.
+
+```lua
+--[[
+--name = "Regex"
+--]]
+function regex_example()
+  local regex = require("@lmb/regex")
+
+  -- Match: returns the first match, or nil when there is none
+  assert(regex.match("hello world", "\\w+") == "hello", "match should return first word")
+
+  -- Captures: capture groups of the first match, excluding the whole match
+  local caps = regex.captures("2026-02-09", "(\\d{4})-(\\d{2})-(\\d{2})")
+  assert(caps[1] == "2026" and caps[2] == "02" and caps[3] == "09", "captures should return groups")
+
+  -- Find every match
+  local all = regex.find_all("a1b2c3", "\\d+")
+  assert(#all == 3, "find_all should return 3 matches")
+
+  -- Replace the first occurrence, or every occurrence
+  assert(regex.replace("foo bar baz", "\\s+", "-") == "foo-bar baz", "replace first only")
+  assert(regex.replace_all("a1b2c3", "\\d", "X") == "aXbXcX", "replace_all")
+
+  -- Split on a pattern, collapsing repeated separators
+  local parts = regex.split("a,b,,c", ",+")
+  assert(#parts == 3, "split should collapse repeated separators")
+
+  -- Boolean test
+  assert(regex.is_match("hello123", "\\d+"), "is_match should be true")
+end
+
+return regex_example
+```
+
 ## Encoding and decoding
 
 ### JSON

--- a/src/bindings/mod.rs
+++ b/src/bindings/mod.rs
@@ -41,6 +41,7 @@ pub(crate) mod io;
 pub(crate) mod json;
 pub(crate) mod json_path;
 pub(crate) mod logging;
+pub(crate) mod regex;
 pub(crate) mod store;
 pub(crate) mod time;
 pub(crate) mod toml;

--- a/src/bindings/regex.rs
+++ b/src/bindings/regex.rs
@@ -1,0 +1,114 @@
+//! Regular expression binding module.
+//!
+//! Luau's built-in `string.match`/`string.find`/`string.gmatch` only support Lua
+//! patterns, which lack features such as alternation, lookahead, and non-greedy
+//! quantifiers. This module exposes the Rust [`regex`] crate, which is fast and
+//! safe (guaranteed linear time, no catastrophic backtracking).
+//! Import via `require("@lmb/regex")`.
+//!
+//! # Available Methods
+//!
+//! - `match(text, pattern)` - Returns the first match, or `nil` when there is none.
+//! - `captures(text, pattern)` - Returns the capture groups of the first match as a
+//!   table (excluding the whole match), or `nil` when there is no match.
+//! - `find_all(text, pattern)` - Returns every match as a table.
+//! - `replace(text, pattern, replacement)` - Replaces the first occurrence.
+//! - `replace_all(text, pattern, replacement)` - Replaces every occurrence.
+//! - `split(text, pattern)` - Splits `text` on the pattern and returns a table of parts.
+//! - `is_match(text, pattern)` - Returns a boolean indicating whether the pattern matches.
+//!
+//! Invalid patterns raise a Lua error.
+//!
+//! # Example
+//!
+//! ```lua
+//! local regex = require("@lmb/regex")
+//!
+//! local m = regex.match("hello world", "\\w+")        -- "hello"
+//! local caps = regex.captures("2026-02-09", "(\\d{4})-(\\d{2})-(\\d{2})")
+//! -- caps = {"2026", "02", "09"}
+//! local all = regex.find_all("a1b2c3", "\\d+")         -- {"1", "2", "3"}
+//! local s = regex.replace("foo bar", "\\s+", "-")      -- "foo-bar"
+//! local s = regex.replace_all("a1b2c3", "\\d", "X")    -- "aXbXcX"
+//! local parts = regex.split("a,b,,c", ",+")            -- {"a", "b", "c"}
+//! local ok = regex.is_match("hello123", "\\d+")        -- true
+//! ```
+
+use mlua::prelude::*;
+use regex::Regex;
+
+pub(crate) struct RegexBinding;
+
+impl LuaUserData for RegexBinding {
+    fn add_methods<M: LuaUserDataMethods<Self>>(methods: &mut M) {
+        methods.add_function("match", |_, (text, pattern): (String, String)| {
+            let re = Regex::new(&pattern).into_lua_err()?;
+            Ok(re.find(&text).map(|m| m.as_str().to_string()))
+        });
+
+        methods.add_function("captures", |vm, (text, pattern): (String, String)| {
+            let re = Regex::new(&pattern).into_lua_err()?;
+            match re.captures(&text) {
+                Some(caps) => {
+                    let groups: Vec<Option<String>> = caps
+                        .iter()
+                        .skip(1)
+                        .map(|g| g.map(|m| m.as_str().to_string()))
+                        .collect();
+                    vm.to_value(&groups)
+                }
+                None => Ok(LuaNil),
+            }
+        });
+
+        methods.add_function("find_all", |vm, (text, pattern): (String, String)| {
+            let re = Regex::new(&pattern).into_lua_err()?;
+            let matches: Vec<String> = re
+                .find_iter(&text)
+                .map(|m| m.as_str().to_string())
+                .collect();
+            vm.to_value(&matches)
+        });
+
+        methods.add_function(
+            "replace",
+            |_, (text, pattern, replacement): (String, String, String)| {
+                let re = Regex::new(&pattern).into_lua_err()?;
+                Ok(re.replace(&text, replacement.as_str()).into_owned())
+            },
+        );
+
+        methods.add_function(
+            "replace_all",
+            |_, (text, pattern, replacement): (String, String, String)| {
+                let re = Regex::new(&pattern).into_lua_err()?;
+                Ok(re.replace_all(&text, replacement.as_str()).into_owned())
+            },
+        );
+
+        methods.add_function("split", |vm, (text, pattern): (String, String)| {
+            let re = Regex::new(&pattern).into_lua_err()?;
+            let parts: Vec<String> = re.split(&text).map(str::to_string).collect();
+            vm.to_value(&parts)
+        });
+
+        methods.add_function("is_match", |_, (text, pattern): (String, String)| {
+            let re = Regex::new(&pattern).into_lua_err()?;
+            Ok(re.is_match(&text))
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::io::empty;
+
+    use crate::Runner;
+
+    #[tokio::test]
+    async fn test_regex() {
+        let source = include_str!("../fixtures/bindings/regex.lua");
+        let runner = Runner::builder(source, empty()).build().unwrap();
+        runner.invoke().call().await.unwrap().result.unwrap();
+    }
+}

--- a/src/fixtures/bindings/regex.lua
+++ b/src/fixtures/bindings/regex.lua
@@ -1,0 +1,44 @@
+local regex = require("@lmb/regex")
+
+-- match: returns the first match
+assert(regex.match("hello world", "\\w+") == "hello", "match should return first word")
+-- match: returns nil when there is no match
+assert(regex.match("xyz", "\\d+") == nil, "match should return nil when no match")
+
+-- captures: returns capture groups (excluding the whole match)
+local caps = regex.captures("2026-02-09", "(\\d{4})-(\\d{2})-(\\d{2})")
+assert(type(caps) == "table", "captures should return a table")
+assert(#caps == 3, "captures should return 3 groups, got " .. #caps)
+assert(caps[1] == "2026", "group 1 should be 2026, got " .. tostring(caps[1]))
+assert(caps[2] == "02", "group 2 should be 02, got " .. tostring(caps[2]))
+assert(caps[3] == "09", "group 3 should be 09, got " .. tostring(caps[3]))
+-- captures: returns nil when there is no match
+assert(regex.captures("nope", "(\\d+)") == nil, "captures should return nil when no match")
+
+-- find_all: returns every match
+local all = regex.find_all("a1b2c3", "\\d+")
+assert(#all == 3, "find_all should return 3 matches, got " .. #all)
+assert(all[1] == "1" and all[2] == "2" and all[3] == "3", "find_all values")
+-- find_all: returns an empty table when there are no matches
+local none = regex.find_all("abc", "\\d+")
+assert(#none == 0, "find_all should return empty table when no matches")
+
+-- replace: replaces the first occurrence only
+assert(regex.replace("foo bar baz", "\\s+", "-") == "foo-bar baz", "replace first only")
+-- replace_all: replaces every occurrence
+assert(regex.replace_all("a1b2c3", "\\d", "X") == "aXbXcX", "replace_all")
+
+-- split: splits on the pattern, collapsing repeated separators
+local parts = regex.split("a,b,,c", ",+")
+assert(#parts == 3, "split should return 3 parts, got " .. #parts)
+assert(parts[1] == "a" and parts[2] == "b" and parts[3] == "c", "split values")
+
+-- is_match: boolean test
+assert(regex.is_match("hello123", "\\d+") == true, "is_match should be true")
+assert(regex.is_match("hello", "\\d+") == false, "is_match should be false")
+
+-- invalid pattern raises an error
+local ok = pcall(regex.is_match, "x", "(")
+assert(not ok, "invalid pattern should raise an error")
+
+return true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -250,6 +250,7 @@ impl Runner {
             vm.register_module("@lmb/json", bindings::json::JsonBinding {})?;
             vm.register_module("@lmb/json-path", bindings::json_path::JsonPathBinding {})?;
             vm.register_module("@lmb/logging", bindings::logging::LoggingBinding {})?;
+            vm.register_module("@lmb/regex", bindings::regex::RegexBinding {})?;
             vm.register_module("@lmb/time", bindings::time::TimeBinding {})?;
             vm.register_module("@lmb/toml", bindings::toml::TomlBinding {})?;
             vm.register_module("@lmb/yaml", bindings::yaml::YamlBinding {})?;


### PR DESCRIPTION
## Summary

Adds a `@lmb/regex` module that exposes the Rust [`regex`](https://docs.rs/regex) crate to Lua scripts via `require("@lmb/regex")`. Luau's built-in `string.match`/`string.find`/`string.gmatch` only support Lua patterns, which lack alternation, lookahead, and non-greedy quantifiers. The `regex` crate is fast and safe — linear-time matching with no catastrophic backtracking.

## API

```lua
local regex = require("@lmb/regex")

regex.match("hello world", "\\w+")                       -- "hello"
regex.captures("2026-02-09", "(\\d{4})-(\\d{2})-(\\d{2})") -- {"2026", "02", "09"}
regex.find_all("a1b2c3", "\\d+")                          -- {"1", "2", "3"}
regex.replace("foo bar", "\\s+", "-")                     -- "foo-bar"
regex.replace_all("a1b2c3", "\\d", "X")                   -- "aXbXcX"
regex.split("a,b,,c", ",+")                               -- {"a", "b", "c"}
regex.is_match("hello123", "\\d+")                        -- true
```

- `match` / `captures` return `nil` when there is no match.
- `captures` returns the capture groups of the first match, excluding the whole match.
- Invalid patterns raise a Lua error.

## Acceptance criteria

- [x] `regex.match()` returns first match
- [x] `regex.captures()` returns capture groups
- [x] `regex.find_all()` returns all matches
- [x] `regex.replace()` / `regex.replace_all()` for substitution
- [x] `regex.split()` for splitting strings
- [x] `regex.is_match()` for boolean testing
- [x] Unit tests covering all functions
- [x] Add examples to guided tour

## Testing

- New fixture-based unit test `bindings::regex::tests::test_regex` exercising every function.
- Guided-tour example validated by `test_guided_tour`.
- Full suite: 318 tests pass; `cargo fmt --check` and `cargo clippy` clean.

## Notes

Patterns are compiled per call. Caching compiled patterns (suggested in the issue) is left as an optional follow-up since it is not part of the acceptance criteria.

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)