### PR TITLE
feat: add `daemon` subcommand for supervised long-running scripts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3429,6 +3429,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3861,6 +3871,7 @@ dependencies = [
  "mio",
  "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,8 @@ tokio = { version = "1.52.3", default-features = false, features = [
   "io-util",
   "macros",
   "rt-multi-thread",
+  "signal",
+  "time",
 ] }
 toml = "1.1.2"
 tracing = "0.1.41"

--- a/README.md
+++ b/README.md
@@ -42,6 +42,41 @@ tick
 tick
 ```
 
+A more realistic example tails a log file and prints every line containing
+`ERROR`. See [`src/fixtures/daemon/log-watch.lua`](src/fixtures/daemon/log-watch.lua):
+
+```lua
+return function(ctx)
+    local fs = require("@lmb/fs") -- require INSIDE the returned function
+
+    local path = ctx.state.path -- log path passed via --state
+    for line in fs:tail(path, { from = "start", poll_interval = 100 }) do
+        if string.find(line, "ERROR") then
+            print(line)
+        end
+        if ctx.cancelled() then -- graceful shutdown on SIGTERM/SIGINT
+            break
+        end
+    end
+end
+```
+
+```bash
+$ lmb --allow-read /var/log daemon \
+      --file log-watch.lua \
+      --state '{"path": "/var/log/app.log"}'
+```
+
+Notes:
+
+- `require(...)` must be called **inside** the returned function — at the top
+  level the `@lmb/*` modules are not registered yet.
+- `ctx.cancelled()` becomes `true` after a `SIGTERM`/`SIGINT`; check it to stop
+  cleanly. `fs:tail` only re-checks it when a new line arrives, so on a quiet
+  log use a `sleep_ms`-based poll loop instead if you need immediate shutdown.
+- Pass `{"path": "...", "limit": N}` to stop after `N` lines (handy for tests or
+  one-shot scans); omit `limit` to follow the log until stopped.
+
 For more information, please read [the guided tour](docs/guided-tour.md).
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -25,6 +25,23 @@ $ lmb eval --file hello.lua
 Hello, world!
 ```
 
+You can also run a script as a supervised daemon that loops until it is told to stop:
+
+```bash
+$ cat > loop.lua <<EOF
+> return function(ctx)
+>     while not ctx.cancelled() do
+>         print("tick")
+>         sleep_ms(1000)
+>     end
+> end
+> EOF
+
+$ lmb daemon --file loop.lua   # Ctrl-C to stop
+tick
+tick
+```
+
 For more information, please read [the guided tour](docs/guided-tour.md).
 
 ## Features
@@ -32,6 +49,7 @@ For more information, please read [the guided tour](docs/guided-tour.md).
 - Batteries included: Comes with handy libraries such as `crypto`, `fs`, `http`, `json`, `time`, `toml`, `yaml`, and more.
 - Easy to use: Run Lua scripts and functions from the command line.
 - Fast: Optimized for quick execution, making it suitable for low-end hardware.
+- Long-running: Run a script as a supervised daemon (`lmb daemon`) that restarts on failure and shuts down gracefully on `SIGTERM`/`SIGINT`.
 - Secure: Runs Lua code in a sandboxed environment provided by Luau to prevent unwanted side effects.
 
 ## Installation

--- a/docs/superpowers/plans/2026-06-01-daemon-mode.md
+++ b/docs/superpowers/plans/2026-06-01-daemon-mode.md
@@ -1,0 +1,1261 @@
+# Daemon Mode Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `lmb daemon` subcommand that runs a long-lived Luau script under supervision: restart on failure with exponential backoff, graceful shutdown on signal.
+
+**Architecture:** A generic cancellation handle is added to `Runner`; the daemon subcommand owns a thin supervisor loop in `src/daemon.rs` that runs each `invoke` in a spawned task, restarts on failure via a `RestartPolicy`, and on a stop signal cancels cooperatively then force-stops after a grace period.
+
+**Tech Stack:** Rust, tokio (multi-thread runtime + signal), mlua/Luau, clap, jiff (durations), bon (builders), snapbox (CLI tests).
+
+**Spec:** `docs/superpowers/specs/2026-06-01-daemon-mode-design.md`
+
+**Conventions (from CLAUDE.md):**
+- Run tests with `cargo nextest run`, never `cargo test`.
+- Run `cargo fmt` before every commit.
+- Commits MUST be GPG-signed (`git commit -S`). Stage files explicitly by name; never `git add -A`/`.`.
+- Commit messages end with the `Co-Authored-By` trailer shown in the commit steps.
+- All work happens on the existing `feat/daemon-mode` branch.
+
+---
+
+## File Structure
+
+- `Cargo.toml` — add `signal` and `time` to tokio features.
+- `src/lib.rs` — add public `Cancellation` and `Cancelled` types, a `LmbError::Cancelled` variant, a `cancellation` field on `Runner`, and wire it into `invoke()` (interrupt + `ctx.cancelled()`).
+- `src/daemon.rs` — **new**: `RestartPolicy`, `DaemonConfig`, `shutdown_signal()`, and the `run()` supervisor loop. Owns all daemon-specific orchestration so `main.rs` stays thin.
+- `src/main.rs` — declare `mod daemon;`, add the `Daemon` subcommand variant, a `parse_daemon_timeout` helper, and the dispatch arm.
+- `src/fixtures/daemon/return-immediately.lua`, `src/fixtures/daemon/always-error.lua` — **new** fixtures for CLI integration tests.
+- `tests/cli_test.rs` — add a `daemon` test module (snapbox).
+- `README.md` — document the daemon subcommand.
+
+---
+
+## Task 1: Enable tokio `signal` and `time` features
+
+**Files:**
+- Modify: `Cargo.toml:65-71`
+
+- [ ] **Step 1: Add the features**
+
+Edit the tokio dependency feature list to include `signal` and `time` (alphabetical order, matching the existing style):
+
+```toml
+tokio = { version = "1.52.3", default-features = false, features = [
+  "fs",
+  "io-std",
+  "io-util",
+  "macros",
+  "rt-multi-thread",
+  "signal",
+  "time",
+] }
+```
+
+- [ ] **Step 2: Verify it builds**
+
+Run: `cd /home/nixos/Develop/claude/lmb && cargo build`
+Expected: builds successfully (these features are additive).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/nixos/Develop/claude/lmb && cargo fmt
+git add Cargo.toml Cargo.lock
+git commit -S -m "$(cat <<'EOF'
+chore: enable tokio signal and time features for daemon mode
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: `Cancellation` type in lib.rs
+
+A shared, cloneable handle: a cooperative `is_cancelled()` flag plus a force deadline computed from a one-shot cancel `Instant` and a grace `Duration`.
+
+**Files:**
+- Modify: `src/lib.rs` (imports near line 5-13; add type after the `Timeout` impl block, ~line 63)
+- Test: `src/lib.rs` (`#[cfg(test)] mod tests`, ~line 398)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `tests` module in `src/lib.rs`:
+
+```rust
+#[test]
+fn cancellation_flag_and_force_deadline() {
+    use std::time::Duration;
+    let c = Cancellation::new(Duration::from_millis(50));
+    // Not cancelled initially.
+    assert!(!c.is_cancelled());
+    assert!(!c.force_deadline_passed());
+    // After cancel(), the flag is set but the grace window has not elapsed.
+    c.cancel();
+    assert!(c.is_cancelled());
+    assert!(!c.force_deadline_passed());
+    // After the grace window, the force deadline has passed.
+    std::thread::sleep(Duration::from_millis(70));
+    assert!(c.force_deadline_passed());
+}
+```
+
+- [ ] **Step 2: Run it to confirm it fails to compile**
+
+Run: `cd /home/nixos/Develop/claude/lmb && cargo nextest run --lib cancellation_flag_and_force_deadline`
+Expected: FAIL — `cannot find type Cancellation`.
+
+- [ ] **Step 3: Implement `Cancellation`**
+
+In `src/lib.rs`, extend the std imports to include `OnceLock` and `AtomicBool`:
+
+```rust
+use std::{
+    error::Error,
+    fmt,
+    sync::{
+        Arc, OnceLock,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    },
+    time::{Duration, Instant},
+};
+```
+
+Then add this type after the `impl Error for Timeout {}` line (~line 63):
+
+```rust
+/// A cooperative cancellation handle shared between a supervisor and the Lua VM.
+///
+/// `is_cancelled` lets a script poll for shutdown and stop on its own. If it does
+/// not, `force_deadline_passed` reports when the grace period after [`cancel`](Self::cancel)
+/// has elapsed, which the VM interrupt hook uses to forcibly stop a runaway script.
+#[derive(Clone, Debug)]
+pub struct Cancellation {
+    cancelled: Arc<AtomicBool>,
+    cancel_at: Arc<OnceLock<Instant>>,
+    grace: Duration,
+}
+
+impl Cancellation {
+    /// Creates a new, un-cancelled handle with the given force grace period.
+    pub fn new(grace: Duration) -> Self {
+        Self {
+            cancelled: Arc::new(AtomicBool::new(false)),
+            cancel_at: Arc::new(OnceLock::new()),
+            grace,
+        }
+    }
+
+    /// Signals cancellation and records the instant. Idempotent; the first call wins.
+    pub fn cancel(&self) {
+        self.cancelled.store(true, Ordering::SeqCst);
+        let _ = self.cancel_at.set(Instant::now());
+    }
+
+    /// Returns whether cancellation has been signalled (cooperative check).
+    pub fn is_cancelled(&self) -> bool {
+        self.cancelled.load(Ordering::SeqCst)
+    }
+
+    /// Returns whether the grace period has elapsed since cancellation began.
+    pub fn force_deadline_passed(&self) -> bool {
+        self.cancel_at.get().is_some_and(|t| t.elapsed() >= self.grace)
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to confirm it passes**
+
+Run: `cd /home/nixos/Develop/claude/lmb && cargo nextest run --lib cancellation_flag_and_force_deadline`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/nixos/Develop/claude/lmb && cargo fmt
+git add src/lib.rs
+git commit -S -m "$(cat <<'EOF'
+feat: add Cancellation handle for cooperative + forced cancellation
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: `Cancelled` error type + `LmbError` variant
+
+Mirrors the existing `Timeout` marker so a forced cancellation surfaces as a distinct, recognizable error.
+
+**Files:**
+- Modify: `src/lib.rs` (add marker after `Timeout`, ~line 63; add enum variant, ~line 101)
+
+- [ ] **Step 1: Add the `Cancelled` marker type**
+
+In `src/lib.rs`, after the `Cancellation` type from Task 2, add:
+
+```rust
+/// Marker error raised by the VM interrupt hook when a script is forcibly cancelled.
+#[derive(Clone, Debug)]
+pub struct Cancelled;
+
+impl fmt::Display for Cancelled {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Lua script execution was cancelled")
+    }
+}
+
+impl Error for Cancelled {}
+```
+
+- [ ] **Step 2: Add the `LmbError::Cancelled` variant**
+
+In the `LmbError` enum, add this variant after `Timeout` (~line 101):
+
+```rust
+    /// Error when the Lua script is forcibly cancelled during shutdown
+    #[error("Cancelled: {0}")]
+    Cancelled(#[from] Cancelled),
+```
+
+- [ ] **Step 3: Verify it builds**
+
+Run: `cd /home/nixos/Develop/claude/lmb && cargo build`
+Expected: builds successfully.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/nixos/Develop/claude/lmb && cargo fmt
+git add src/lib.rs
+git commit -S -m "$(cat <<'EOF'
+feat: add Cancelled marker error and LmbError::Cancelled variant
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Wire cancellation into `Runner`
+
+Add an optional `cancellation` field to `Runner`, thread it through both builders, and use it in `invoke()` for (a) the interrupt force-stop and (b) the `ctx.cancelled()` Lua function.
+
+**Files:**
+- Modify: `src/lib.rs` — `Runner` struct (~line 125), `new` builder (~line 160), `from_shared_reader` builder (~line 184) + struct literal (~line 262), `invoke()` interrupt block (~line 282-304), ctx build (~line 306-320), error branch (~line 345-356)
+- Test: `src/lib.rs` tests module
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the `tests` module in `src/lib.rs`:
+
+```rust
+#[tokio::test]
+async fn ctx_cancelled_is_observable_and_cooperative() {
+    use std::time::Duration;
+    use tokio::io::empty;
+    let cancellation = Cancellation::new(Duration::from_secs(10));
+    // Script loops until ctx.cancelled() becomes true, then returns "stopped".
+    let source = r#"return function(ctx)
+        while not ctx.cancelled() do sleep_ms(5) end
+        return "stopped"
+    end"#;
+    let runner = Runner::builder(source, empty())
+        .cancellation(cancellation.clone())
+        .build()
+        .unwrap();
+    let handle = tokio::spawn(async move { runner.invoke().call().await });
+    tokio::time::sleep(Duration::from_millis(30)).await;
+    cancellation.cancel();
+    let invoked = handle.await.unwrap().unwrap();
+    assert_eq!(invoked.result.unwrap(), json!("stopped"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cpu_loop_is_force_interrupted_after_grace() {
+    use std::time::Duration;
+    use tokio::io::empty;
+    let cancellation = Cancellation::new(Duration::from_millis(100));
+    // Tight CPU loop that ignores ctx.cancelled().
+    let source = r#"return function(ctx) while true do end end"#;
+    let runner = Runner::builder(source, empty())
+        .cancellation(cancellation.clone())
+        .build()
+        .unwrap();
+    let handle = tokio::spawn(async move { runner.invoke().call().await });
+    cancellation.cancel();
+    let invoked = tokio::time::timeout(Duration::from_secs(5), handle)
+        .await
+        .expect("invoke should be force-interrupted, not hang")
+        .unwrap()
+        .unwrap();
+    assert!(matches!(invoked.result, Err(LmbError::Cancelled(_))));
+}
+```
+
+- [ ] **Step 2: Run them to confirm they fail to compile**
+
+Run: `cd /home/nixos/Develop/claude/lmb && cargo nextest run --lib ctx_cancelled_is_observable_and_cooperative cpu_loop_is_force_interrupted_after_grace`
+Expected: FAIL — no `cancellation` builder method.
+
+- [ ] **Step 3: Add the `cancellation` field to `Runner`**
+
+In the `Runner` struct (~line 125):
+
+```rust
+/// A runner for executing Lua scripts with an input stream
+#[derive(Debug)]
+pub struct Runner {
+    cancellation: Option<Cancellation>,
+    func: LuaFunction,
+    reader: LmbInput,
+    store: Option<LmbStore>,
+    timeout: Option<Duration>,
+    vm: Lua,
+}
+```
+
+- [ ] **Step 4: Thread `cancellation` through both builders**
+
+In `new` (~line 160), add the parameter and forward it. The full updated function:
+
+```rust
+    #[builder]
+    pub fn new<S, R>(
+        #[builder(start_fn)] source: S,
+        #[builder(start_fn)] reader: R,
+        cancellation: Option<Cancellation>,
+        #[builder(into)] default_name: Option<String>,
+        http_timeout: Option<Duration>,
+        permissions: Option<Permissions>,
+        store: Option<Arc<dyn StoreBackend>>,
+        timeout: Option<Duration>,
+    ) -> LmbResult<Self>
+    where
+        S: AsChunk + Clone,
+        R: AsyncRead + Send + Unpin + 'static,
+    {
+        let reader = Arc::new(SharedReader::new(reader));
+        Self::from_shared_reader(source, reader)
+            .maybe_cancellation(cancellation)
+            .maybe_default_name(default_name)
+            .maybe_http_timeout(http_timeout)
+            .maybe_permissions(permissions)
+            .maybe_store(store)
+            .maybe_timeout(timeout)
+            .call()
+    }
+```
+
+In `from_shared_reader` (~line 184), add the parameter:
+
+```rust
+    #[builder]
+    pub fn from_shared_reader<S>(
+        #[builder(start_fn)] source: S,
+        #[builder(start_fn)] reader: LmbInput,
+        cancellation: Option<Cancellation>,
+        #[builder(into)] default_name: Option<String>,
+        http_timeout: Option<Duration>,
+        permissions: Option<Permissions>,
+        store: Option<LmbStore>,
+        timeout: Option<Duration>,
+    ) -> LmbResult<Self>
+    where
+        S: AsChunk + Clone,
+    {
+```
+
+And in the struct literal that builds the `Runner` (~line 262), add the field:
+
+```rust
+        let mut runner = Self {
+            cancellation,
+            func,
+            reader,
+            store,
+            timeout,
+            vm, // otherwise the Lua VM would be destroyed
+        };
+```
+
+- [ ] **Step 5: Use cancellation in the `invoke()` interrupt hook**
+
+Replace the entire `if let Some(timeout) = self.timeout { ... } else { ... }` interrupt block (~line 282-304) with a single closure that checks both timeout and cancellation:
+
+```rust
+        let timeout = self.timeout;
+        let cancellation = self.cancellation.clone();
+        self.vm.set_interrupt({
+            let used_memory = used_memory.clone();
+            move |vm| {
+                used_memory.fetch_max(vm.used_memory(), Ordering::Relaxed);
+                if let Some(timeout) = timeout {
+                    if start.elapsed() > timeout {
+                        return Err(LuaError::external(Timeout {
+                            elapsed: start.elapsed(),
+                            timeout,
+                        }));
+                    }
+                }
+                if let Some(cancellation) = &cancellation {
+                    if cancellation.force_deadline_passed() {
+                        return Err(LuaError::external(Cancelled));
+                    }
+                }
+                Ok(LuaVmState::Continue)
+            }
+        });
+```
+
+- [ ] **Step 6: Inject `ctx.cancelled()` when a handle is present**
+
+After the store block that sets `ctx.set("store", ...)` (~line 320), add:
+
+```rust
+        if let Some(cancellation) = &self.cancellation {
+            let cancellation = cancellation.clone();
+            ctx.set(
+                "cancelled",
+                self.vm
+                    .create_function(move |_, ()| Ok(cancellation.is_cancelled()))?,
+            )?;
+        }
+```
+
+- [ ] **Step 7: Recognize `Cancelled` in the error branch**
+
+In the `call_async` error branch, extend the `LuaError::ExternalError` match (~line 345-356) to downcast `Cancelled`:
+
+```rust
+                Err(e) => match &e {
+                    LuaError::ExternalError(ee) => {
+                        if let Some(timeout) = ee.downcast_ref::<Timeout>() {
+                            return Ok(invoked
+                                .result(Err(LmbError::Timeout(timeout.clone())))
+                                .build());
+                        } else if ee.downcast_ref::<Cancelled>().is_some() {
+                            return Ok(invoked
+                                .result(Err(LmbError::Cancelled(Cancelled)))
+                                .build());
+                        } else {
+                            return Ok(invoked.result(Err(LmbError::Lua(e))).build());
+                        }
+                    }
+                    _ => return Ok(invoked.result(Err(LmbError::Lua(e))).build()),
+                },
+```
+
+- [ ] **Step 8: Run the tests to confirm they pass**
+
+Run: `cd /home/nixos/Develop/claude/lmb && cargo nextest run --lib`
+Expected: PASS (including the two new tests and all existing tests — the new builder field is optional, so existing call sites are unaffected).
+
+- [ ] **Step 9: Commit**
+
+```bash
+cd /home/nixos/Develop/claude/lmb && cargo fmt
+git add src/lib.rs
+git commit -S -m "$(cat <<'EOF'
+feat: wire optional cancellation into Runner invoke
+
+Adds ctx.cancelled() for cooperative shutdown and a force-interrupt path
+in the VM interrupt hook once the grace deadline passes.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: `RestartPolicy` in `src/daemon.rs`
+
+Pure, synchronous restart accounting: exponential backoff with a cap, plus a consecutive-failure counter that resets after a stable run.
+
+**Files:**
+- Create: `src/daemon.rs`
+- Modify: `src/main.rs` (add `mod daemon;` near line 28-29)
+
+- [ ] **Step 1: Create `src/daemon.rs` with the failing test**
+
+Create `src/daemon.rs`:
+
+```rust
+//! Supervised long-running daemon mode.
+
+use std::time::Duration;
+
+/// What the supervisor should do after a failed run.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum RestartDecision {
+    /// Wait this long, then restart.
+    Backoff(Duration),
+    /// Stop restarting; the daemon should exit non-zero.
+    GiveUp,
+}
+
+/// Tracks exponential restart backoff and the consecutive-failure count.
+pub(crate) struct RestartPolicy {
+    initial: Duration,
+    max_backoff: Duration,
+    reset_after: Duration,
+    max_restarts: u32,
+    current_backoff: Duration,
+    consecutive: u32,
+}
+
+impl RestartPolicy {
+    pub(crate) fn new(
+        initial: Duration,
+        max_backoff: Duration,
+        reset_after: Duration,
+        max_restarts: u32,
+    ) -> Self {
+        Self {
+            initial,
+            max_backoff,
+            reset_after,
+            max_restarts,
+            current_backoff: initial,
+            consecutive: 0,
+        }
+    }
+
+    /// Records a failed run of the given duration and returns what to do next.
+    pub(crate) fn record_failure(&mut self, run_duration: Duration) -> RestartDecision {
+        if run_duration >= self.reset_after {
+            self.current_backoff = self.initial;
+            self.consecutive = 0;
+        }
+        self.consecutive += 1;
+        if self.max_restarts != 0 && self.consecutive >= self.max_restarts {
+            return RestartDecision::GiveUp;
+        }
+        let wait = self.current_backoff;
+        self.current_backoff = (self.current_backoff * 2).min(self.max_backoff);
+        RestartDecision::Backoff(wait)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn secs(n: u64) -> Duration {
+        Duration::from_secs(n)
+    }
+
+    #[test]
+    fn backoff_grows_exponentially_and_caps() {
+        // reset_after huge so no run counts as stable; max_restarts unlimited.
+        let mut p = RestartPolicy::new(secs(1), secs(8), secs(3600), 0);
+        // Short failures (0s) never reset.
+        assert_eq!(p.record_failure(secs(0)), RestartDecision::Backoff(secs(1)));
+        assert_eq!(p.record_failure(secs(0)), RestartDecision::Backoff(secs(2)));
+        assert_eq!(p.record_failure(secs(0)), RestartDecision::Backoff(secs(4)));
+        assert_eq!(p.record_failure(secs(0)), RestartDecision::Backoff(secs(8)));
+        // Capped at max_backoff.
+        assert_eq!(p.record_failure(secs(0)), RestartDecision::Backoff(secs(8)));
+    }
+
+    #[test]
+    fn stable_run_resets_backoff_and_counter() {
+        let mut p = RestartPolicy::new(secs(1), secs(60), secs(10), 0);
+        assert_eq!(p.record_failure(secs(0)), RestartDecision::Backoff(secs(1)));
+        assert_eq!(p.record_failure(secs(0)), RestartDecision::Backoff(secs(2)));
+        // A run that lasted >= reset_after resets backoff to initial.
+        assert_eq!(p.record_failure(secs(20)), RestartDecision::Backoff(secs(1)));
+    }
+
+    #[test]
+    fn gives_up_after_max_consecutive_failures() {
+        let mut p = RestartPolicy::new(secs(0), secs(0), secs(3600), 3);
+        assert_eq!(p.record_failure(secs(0)), RestartDecision::Backoff(secs(0)));
+        assert_eq!(p.record_failure(secs(0)), RestartDecision::Backoff(secs(0)));
+        assert_eq!(p.record_failure(secs(0)), RestartDecision::GiveUp);
+    }
+
+    #[test]
+    fn stable_run_prevents_giving_up() {
+        let mut p = RestartPolicy::new(secs(0), secs(0), secs(10), 2);
+        assert_eq!(p.record_failure(secs(0)), RestartDecision::Backoff(secs(0)));
+        // Stable run resets the counter, so the next failure is counted as the first.
+        assert_eq!(p.record_failure(secs(20)), RestartDecision::Backoff(secs(0)));
+        assert_eq!(p.record_failure(secs(0)), RestartDecision::GiveUp);
+    }
+}
+```
+
+Add `mod daemon;` to `src/main.rs` next to the other module declarations (~line 28):
+
+```rust
+mod daemon;
+mod serve;
+mod tour;
+```
+
+- [ ] **Step 2: Run the tests to confirm they pass**
+
+Run: `cd /home/nixos/Develop/claude/lmb && cargo nextest run --bin lmb restart`
+Expected: PASS for all four `RestartPolicy` tests.
+
+(Note: `mod daemon;` will trigger dead-code warnings for `DaemonConfig`/`run` until later tasks; that is expected and resolved by Task 7. If warnings are denied in CI, they only fire on unused items — added next tasks.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/nixos/Develop/claude/lmb && cargo fmt
+git add src/daemon.rs src/main.rs
+git commit -S -m "$(cat <<'EOF'
+feat: add RestartPolicy for daemon backoff and give-up accounting
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: `DaemonConfig`, `shutdown_signal()`, and the `run()` supervisor loop
+
+The supervisor: build a fresh `Runner` each iteration, spawn `invoke` as a task, select between completion and shutdown, restart on failure, force-stop after grace. `run()` takes the shutdown trigger as a parameter so it is testable without OS signals.
+
+**Files:**
+- Modify: `src/daemon.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the `tests` module in `src/daemon.rs`:
+
+```rust
+    use std::future::pending;
+
+    fn config(source: &str, max_restarts: u32, grace: Duration) -> DaemonConfig {
+        DaemonConfig::builder()
+            .source(source.to_string())
+            .initial_backoff(Duration::ZERO)
+            .max_backoff(Duration::ZERO)
+            .reset_after(secs(3600))
+            .max_restarts(max_restarts)
+            .grace(grace)
+            .build()
+    }
+
+    #[tokio::test]
+    async fn exits_success_when_script_returns() {
+        let cfg = config("return function(ctx) return 1 end", 0, secs(1));
+        let code = run(cfg, pending::<()>()).await.unwrap();
+        assert_eq!(code, 0);
+    }
+
+    #[tokio::test]
+    async fn exits_failure_after_max_restarts() {
+        let cfg = config("return function(ctx) error('boom') end", 2, secs(1));
+        let code = run(cfg, pending::<()>()).await.unwrap();
+        assert_eq!(code, 1);
+    }
+
+    #[tokio::test]
+    async fn graceful_shutdown_cooperative_returns_success() {
+        let cfg = config(
+            "return function(ctx) while not ctx.cancelled() do sleep_ms(5) end return end",
+            0,
+            secs(1),
+        );
+        let shutdown = async { tokio::time::sleep(Duration::from_millis(40)).await };
+        let code = tokio::time::timeout(secs(5), run(cfg, shutdown))
+            .await
+            .expect("should not hang")
+            .unwrap();
+        assert_eq!(code, 0);
+    }
+
+    #[tokio::test]
+    async fn graceful_shutdown_abandons_async_parked_script() {
+        let cfg = config(
+            "return function(ctx) sleep_ms(600000) end",
+            0,
+            Duration::from_millis(150),
+        );
+        let shutdown = async { tokio::time::sleep(Duration::from_millis(40)).await };
+        let code = tokio::time::timeout(secs(5), run(cfg, shutdown))
+            .await
+            .expect("should not hang")
+            .unwrap();
+        assert_eq!(code, 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn graceful_shutdown_force_interrupts_cpu_loop() {
+        let cfg = config(
+            "return function(ctx) while true do end end",
+            0,
+            Duration::from_millis(150),
+        );
+        let shutdown = async { tokio::time::sleep(Duration::from_millis(40)).await };
+        let code = tokio::time::timeout(secs(5), run(cfg, shutdown))
+            .await
+            .expect("should not hang")
+            .unwrap();
+        assert_eq!(code, 0);
+    }
+```
+
+- [ ] **Step 2: Run them to confirm they fail to compile**
+
+Run: `cd /home/nixos/Develop/claude/lmb && cargo nextest run --bin lmb exits_success_when_script_returns`
+Expected: FAIL — `DaemonConfig`, `run` not found.
+
+- [ ] **Step 3: Implement `DaemonConfig`, `shutdown_signal()`, and `run()`**
+
+At the top of `src/daemon.rs`, update imports and add the implementation (place above the `#[cfg(test)]` module):
+
+```rust
+//! Supervised long-running daemon mode.
+
+use std::{future::Future, sync::Arc, time::Duration, time::Instant};
+
+use bon::Builder;
+use lmb::{Cancellation, LmbStore, Runner, State, permission::Permissions};
+use serde_json::Value;
+use tokio::io::empty;
+use tracing::{info, warn};
+```
+
+```rust
+/// Configuration for a daemon run.
+#[derive(Builder)]
+pub(crate) struct DaemonConfig {
+    #[builder(into)]
+    pub source: String,
+    #[builder(into)]
+    pub name: Option<String>,
+    pub state: Option<Value>,
+    pub permissions: Option<Permissions>,
+    pub store: Option<LmbStore>,
+    pub http_timeout: Option<Duration>,
+    pub timeout: Option<Duration>,
+    pub initial_backoff: Duration,
+    pub max_backoff: Duration,
+    pub reset_after: Duration,
+    pub max_restarts: u32,
+    pub grace: Duration,
+}
+
+/// Builds a fresh `Runner` for one supervised run.
+fn build_runner(config: &DaemonConfig, cancellation: Cancellation) -> anyhow::Result<Runner> {
+    let runner = Runner::builder(config.source.clone(), empty())
+        .cancellation(cancellation)
+        .maybe_default_name(config.name.clone())
+        .maybe_http_timeout(config.http_timeout)
+        .maybe_permissions(config.permissions.clone())
+        .maybe_store(config.store.clone())
+        .maybe_timeout(config.timeout)
+        .build()?;
+    Ok(runner)
+}
+
+/// Resolves whether a finished run was a clean completion or a failure.
+fn was_failure(joined: Result<lmb::LmbResult<lmb::Invoked>, tokio::task::JoinError>) -> bool {
+    match joined {
+        Ok(Ok(invoked)) => match invoked.result {
+            Ok(_) => false,
+            Err(e) => {
+                warn!("script failed: {e}");
+                true
+            }
+        },
+        Ok(Err(e)) => {
+            warn!("invoke error: {e}");
+            true
+        }
+        Err(e) => {
+            warn!("daemon task panicked: {e}");
+            true
+        }
+    }
+}
+
+/// Future that resolves when a stop signal (SIGTERM/SIGINT) is received.
+#[cfg(unix)]
+pub(crate) async fn shutdown_signal() {
+    use tokio::signal::unix::{SignalKind, signal};
+    let mut term = signal(SignalKind::terminate()).expect("install SIGTERM handler");
+    let mut int = signal(SignalKind::interrupt()).expect("install SIGINT handler");
+    tokio::select! {
+        _ = term.recv() => {},
+        _ = int.recv() => {},
+    }
+}
+
+/// Future that resolves when Ctrl-C is received (non-Unix fallback).
+#[cfg(not(unix))]
+pub(crate) async fn shutdown_signal() {
+    let _ = tokio::signal::ctrl_c().await;
+}
+
+/// Runs the supervised loop until the script completes, the restart policy gives
+/// up, or a shutdown is requested. Returns the process exit code (0 = success).
+pub(crate) async fn run<F>(config: DaemonConfig, shutdown: F) -> anyhow::Result<u8>
+where
+    F: Future<Output = ()>,
+{
+    let cancellation = Cancellation::new(config.grace);
+    let mut policy = RestartPolicy::new(
+        config.initial_backoff,
+        config.max_backoff,
+        config.reset_after,
+        config.max_restarts,
+    );
+    tokio::pin!(shutdown);
+
+    loop {
+        let runner = build_runner(&config, cancellation.clone())?;
+        let state = config.state.clone();
+        let start = Instant::now();
+        let mut handle = tokio::spawn(async move {
+            let state = State::builder().maybe_state(state).build();
+            runner.invoke().state(state).call().await
+        });
+
+        let shutting_down = tokio::select! {
+            joined = &mut handle => {
+                if !was_failure(joined) {
+                    info!("script returned, daemon exiting");
+                    return Ok(0);
+                }
+                false
+            }
+            _ = &mut shutdown => {
+                info!("received stop signal, shutting down");
+                cancellation.cancel();
+                tokio::select! {
+                    _ = &mut handle => {}
+                    _ = tokio::time::sleep(config.grace) => {
+                        warn!("grace period elapsed, aborting script");
+                        handle.abort();
+                        let _ = handle.await;
+                    }
+                }
+                true
+            }
+        };
+
+        if shutting_down {
+            return Ok(0);
+        }
+
+        match policy.record_failure(start.elapsed()) {
+            RestartDecision::GiveUp => {
+                warn!("max restarts reached, giving up");
+                return Ok(1);
+            }
+            RestartDecision::Backoff(wait) => {
+                info!("restarting in {wait:?}");
+                tokio::select! {
+                    _ = tokio::time::sleep(wait) => {}
+                    _ = &mut shutdown => {
+                        info!("stop signal during backoff, exiting");
+                        return Ok(0);
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to confirm they pass**
+
+Run: `cd /home/nixos/Develop/claude/lmb && cargo nextest run --bin lmb`
+Expected: PASS for all daemon tests (`exits_success_when_script_returns`, `exits_failure_after_max_restarts`, `graceful_shutdown_cooperative_returns_success`, `graceful_shutdown_abandons_async_parked_script`, `graceful_shutdown_force_interrupts_cpu_loop`) plus the `RestartPolicy` tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/nixos/Develop/claude/lmb && cargo fmt
+git add src/daemon.rs
+git commit -S -m "$(cat <<'EOF'
+feat: add daemon supervisor loop with graceful shutdown
+
+Spawns each invoke as a task so a CPU-bound loop cannot starve the signal
+branch; cancels cooperatively then force-stops (interrupt or abort) after
+the grace period.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: CLI wiring in `src/main.rs`
+
+Add the `Daemon` subcommand, a daemon-specific timeout resolver (default disabled), and the dispatch arm.
+
+**Files:**
+- Modify: `src/main.rs` — imports (~line 1-26), `parse_daemon_timeout` helper (near `parse_timeout`, ~line 189), `Command` enum (~line 187), dispatch match (~line 499)
+
+- [ ] **Step 1: Add the `parse_daemon_timeout` helper**
+
+In `src/main.rs`, after the existing `parse_timeout` function (~line 195), add:
+
+```rust
+/// Like `parse_timeout`, but defaults to disabled (None) when unspecified, since
+/// a supervised loop is expected to run indefinitely.
+fn parse_daemon_timeout(span: Option<jiff::Span>) -> anyhow::Result<Option<Duration>> {
+    match span {
+        None => Ok(None),
+        Some(t) if t.is_zero() => Ok(None),
+        Some(t) => Ok(Some(Duration::try_from(t)?)),
+    }
+}
+```
+
+Add a unit test at the end of `src/main.rs` (create the module if it does not exist):
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn daemon_timeout_defaults_to_disabled() {
+        // Unspecified -> disabled (unlike eval/serve which default to 30s).
+        assert_eq!(parse_daemon_timeout(None).unwrap(), None);
+        // Explicit zero -> disabled.
+        assert_eq!(
+            parse_daemon_timeout(Some("0s".parse().unwrap())).unwrap(),
+            None
+        );
+        // Explicit non-zero -> that duration.
+        assert_eq!(
+            parse_daemon_timeout(Some("5s".parse().unwrap())).unwrap(),
+            Some(Duration::from_secs(5))
+        );
+    }
+}
+```
+
+Run: `cd /home/nixos/Develop/claude/lmb && cargo nextest run --bin lmb daemon_timeout_defaults_to_disabled`
+Expected: PASS.
+
+- [ ] **Step 2: Add the `Daemon` variant to the `Command` enum**
+
+In the `Command` enum, after the `Serve { ... }` variant (~line 186), add:
+
+```rust
+    /// Run a Lua script as a supervised long-running daemon (no HTTP)
+    #[clap(after_help = "\
+EXAMPLES:
+    lmb daemon --file loop.lua
+    lmb daemon --file loop.lua --shutdown-grace 30s
+    lmb daemon --file loop.lua --restart-max-backoff 2m --max-restarts 10")]
+    Daemon {
+        /// Path to the Lua script file, use '-' for stdin
+        #[clap(long, value_parser, env = "FILE_PATH")]
+        file: Input,
+        /// JSON state passed to the Lua script as ctx.state
+        #[clap(long, env = "STATE")]
+        state: Option<String>,
+        /// Initial backoff after a failure (e.g., 1s)
+        #[clap(long, default_value = "1s", env = "RESTART_INITIAL_BACKOFF")]
+        restart_initial_backoff: jiff::Span,
+        /// Maximum backoff between restarts (e.g., 60s)
+        #[clap(long, default_value = "60s", env = "RESTART_MAX_BACKOFF")]
+        restart_max_backoff: jiff::Span,
+        /// Reset backoff and failure count after the script runs stably this long
+        #[clap(long, default_value = "60s", env = "RESTART_RESET_AFTER")]
+        restart_reset_after: jiff::Span,
+        /// Give up after this many consecutive failures (0 = unlimited)
+        #[clap(long, default_value_t = 0, env = "MAX_RESTARTS")]
+        max_restarts: u32,
+        /// Grace period for the script to stop after a signal (e.g., 10s)
+        #[clap(long, default_value = "10s", env = "SHUTDOWN_GRACE")]
+        shutdown_grace: jiff::Span,
+    },
+```
+
+- [ ] **Step 3: Add the dispatch arm**
+
+In the `match opts.command` block, after the `Command::Serve { ... } => { ... }` arm (~line 498), add:
+
+```rust
+        Command::Daemon {
+            mut file,
+            state,
+            restart_initial_backoff,
+            restart_max_backoff,
+            restart_reset_after,
+            max_restarts,
+            shutdown_grace,
+        } => {
+            let state = state
+                .as_ref()
+                .map(|s| match serde_json::from_str::<Value>(s) {
+                    Ok(value) => value,
+                    Err(_) => json!(s.clone()), // treat invalid value as string
+                });
+            debug!("State: {state:?}");
+
+            let http_timeout = parse_timeout(opts.http_timeout)?;
+            let timeout = parse_daemon_timeout(opts.timeout)?;
+            debug!("Using timeout: {timeout:?}");
+
+            let mut source = String::new();
+            file.read_to_string(&mut source)?;
+
+            let name = if file.is_local() {
+                file.path().to_string_lossy().to_string()
+            } else if file.is_std() {
+                "(stdin)".to_string()
+            } else {
+                bail!("Expected a local file or a stdin input, but got: {file}");
+            };
+
+            if opts.store_path.is_none() && !opts.no_store {
+                #[cfg(feature = "postgres")]
+                if opts.store_url.is_none() {
+                    warn!("No store path specified, using in-memory store");
+                }
+                #[cfg(not(feature = "postgres"))]
+                warn!("No store path specified, using in-memory store");
+            }
+            let store = open_store_connection(
+                opts.store_path,
+                #[cfg(feature = "postgres")]
+                opts.store_url,
+                opts.no_store,
+            )?;
+
+            let config = daemon::DaemonConfig::builder()
+                .source(source)
+                .maybe_name(Some(name))
+                .maybe_state(state)
+                .permissions(permissions)
+                .maybe_store(store)
+                .maybe_http_timeout(http_timeout)
+                .maybe_timeout(timeout)
+                .initial_backoff(Duration::try_from(restart_initial_backoff)?)
+                .max_backoff(Duration::try_from(restart_max_backoff)?)
+                .reset_after(Duration::try_from(restart_reset_after)?)
+                .max_restarts(max_restarts)
+                .grace(Duration::try_from(shutdown_grace)?)
+                .build();
+
+            let code = daemon::run(config, daemon::shutdown_signal()).await?;
+            if code != 0 {
+                std::process::exit(i32::from(code));
+            }
+        }
+```
+
+- [ ] **Step 4: Verify it builds**
+
+Run: `cd /home/nixos/Develop/claude/lmb && cargo build`
+Expected: builds successfully with no dead-code warnings (all daemon items are now used).
+
+- [ ] **Step 5: Manual smoke test**
+
+Run a short cooperative script and interrupt it:
+
+```bash
+cd /home/nixos/Develop/claude/lmb
+printf 'return function(ctx)\n  while not ctx.cancelled() do sleep_ms(200) end\n  return\nend\n' > /tmp/loop.lua
+cargo run -- --no-store daemon --file /tmp/loop.lua &
+sleep 1; kill -TERM %1; wait %1; echo "exit: $?"
+```
+Expected: process exits cleanly (`exit: 0`) within the grace period.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/nixos/Develop/claude/lmb && cargo fmt
+git add src/main.rs
+git commit -S -m "$(cat <<'EOF'
+feat: add `lmb daemon` subcommand wiring
+
+Timeout defaults to disabled in daemon mode; reuses the global permission
+and store options; SIGTERM/SIGINT drive graceful shutdown.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: CLI integration tests (snapbox)
+
+**Files:**
+- Create: `src/fixtures/daemon/return-immediately.lua`, `src/fixtures/daemon/always-error.lua`
+- Modify: `tests/cli_test.rs` (add a `daemon` module)
+
+- [ ] **Step 1: Create the fixtures**
+
+`src/fixtures/daemon/return-immediately.lua`:
+
+```lua
+return function(ctx)
+    return true
+end
+```
+
+`src/fixtures/daemon/always-error.lua`:
+
+```lua
+return function(ctx)
+    error("boom")
+end
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Add to `tests/cli_test.rs`, after the existing top-level test modules:
+
+```rust
+mod daemon {
+    use super::*;
+
+    #[test]
+    fn exits_success_when_script_returns() {
+        Command::new(cmd::cargo_bin!("lmb"))
+            .env("NO_COLOR", "true")
+            .args([
+                "--no-store",
+                "daemon",
+                "--file",
+                "src/fixtures/daemon/return-immediately.lua",
+            ])
+            .assert()
+            .success()
+            .stdout_eq(str![]);
+    }
+
+    #[test]
+    fn exits_failure_after_max_restarts() {
+        Command::new(cmd::cargo_bin!("lmb"))
+            .env("NO_COLOR", "true")
+            .args([
+                "--no-store",
+                "daemon",
+                "--file",
+                "src/fixtures/daemon/always-error.lua",
+                "--restart-initial-backoff",
+                "0s",
+                "--restart-max-backoff",
+                "0s",
+                "--max-restarts",
+                "1",
+            ])
+            .assert()
+            .failure();
+    }
+}
+```
+
+- [ ] **Step 3: Run them to confirm they pass**
+
+Run: `cd /home/nixos/Develop/claude/lmb && cargo nextest run --test cli_test daemon`
+Expected: PASS. The success case produces no stdout (the daemon does not print the script's return value); the failure case exits non-zero after one failed run.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/nixos/Develop/claude/lmb && cargo fmt
+git add src/fixtures/daemon/return-immediately.lua src/fixtures/daemon/always-error.lua tests/cli_test.rs
+git commit -S -m "$(cat <<'EOF'
+test: add daemon CLI integration tests
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: Documentation
+
+**Files:**
+- Modify: `README.md` (Features list ~line 31-36; add a usage example near the existing eval example)
+- Modify: `src/main.rs` (`AFTER_HELP` constant ~line 40-61)
+
+- [ ] **Step 1: Update README features and add an example**
+
+In `README.md`, add a bullet to the Features list:
+
+```markdown
+- Long-running: Run a script as a supervised daemon (`lmb daemon`) that restarts on failure and shuts down gracefully on `SIGTERM`/`SIGINT`.
+```
+
+After the existing `lmb eval` example block, add:
+
+```markdown
+You can also run a script as a supervised daemon that loops until it is told to stop:
+
+```bash
+$ cat > loop.lua <<EOF
+> return function(ctx)
+>     while not ctx.cancelled() do
+>         print("tick")
+>         sleep_ms(1000)
+>     end
+> end
+> EOF
+
+$ lmb daemon --file loop.lua   # Ctrl-C to stop
+tick
+tick
+```
+```
+
+- [ ] **Step 2: Add a daemon example to `AFTER_HELP`**
+
+In `src/main.rs`, add to the `AFTER_HELP` string after the "Start an HTTP server" example:
+
+```rust
+    Run a supervised daemon:
+        lmb daemon --file loop.lua
+```
+
+- [ ] **Step 3: Verify the help renders**
+
+Run: `cd /home/nixos/Develop/claude/lmb && cargo run -- --help` and `cargo run -- daemon --help`
+Expected: the daemon subcommand and example appear; daemon help lists all the restart/grace flags.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/nixos/Develop/claude/lmb && cargo fmt
+git add README.md src/main.rs
+git commit -S -m "$(cat <<'EOF'
+docs: document the daemon subcommand
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Final verification
+
+- [ ] **Step 1: Full test suite**
+
+Run: `cd /home/nixos/Develop/claude/lmb && cargo nextest run`
+Expected: all tests pass.
+
+- [ ] **Step 2: Lint**
+
+Run: `cd /home/nixos/Develop/claude/lmb && cargo clippy --all-targets -- -D warnings`
+Expected: no warnings.
+
+- [ ] **Step 3: Format check**
+
+Run: `cd /home/nixos/Develop/claude/lmb && cargo fmt --check`
+Expected: clean.

--- a/docs/superpowers/specs/2026-06-01-daemon-mode-design.md
+++ b/docs/superpowers/specs/2026-06-01-daemon-mode-design.md
@@ -71,18 +71,19 @@ The supervisor is a thin Rust loop. Each run's `invoke` is executed in its own
 This is required: a CPU-bound Lua loop that never yields would block the poll of
 an inlined future and starve the signal branch, so the supervisor could never
 react to a stop signal. Running `invoke` as a separate task (on the
-multi-threaded runtime) keeps the supervisor responsive. The supervisor holds an
-`Arc<Runner>` and clones it into the task. Pseudocode:
+multi-threaded runtime) keeps the supervisor responsive. Each freshly built `Runner` is moved
+into its task (the next iteration builds a new VM anyway, so the supervisor does
+not need it back). Pseudocode:
 
 ```
 backoff = initial
 restarts = 0
 loop {
     start = now
-    runner = Arc::new(rebuild_runner())         // fresh VM; reused store Arc
-    handle = tokio::spawn({ let r = runner.clone(); async move {
-        r.invoke(state.clone()).await           // -> LmbResult<Invoked>
-    }})
+    runner = rebuild_runner()                   // fresh VM; reused store Arc
+    handle = tokio::spawn(async move {          // move owned Runner into the task
+        runner.invoke(state.clone()).await      // -> LmbResult<Invoked>
+    })
     outcome = select! {
         r = &mut handle => Finished(r)          // script returned or errored
         _ = shutdown_signal() => {              // SIGTERM / SIGINT

--- a/docs/superpowers/specs/2026-06-01-daemon-mode-design.md
+++ b/docs/superpowers/specs/2026-06-01-daemon-mode-design.md
@@ -66,28 +66,35 @@ still set it explicitly to bound a single supervised run.
 
 ## Architecture
 
-The supervisor is a thin Rust loop. On a stop signal the in-flight `invoke`
-future is **kept alive throughout the grace period** — not dropped immediately —
-so the same execution can finish cooperatively. Only once the grace period
-elapses is it abandoned (see "Graceful shutdown"). So the future is pinned and
-the signal branch sets the cancellation flag, then keeps awaiting that same
-future with a grace timeout. Pseudocode:
+The supervisor is a thin Rust loop. Each run's `invoke` is executed in its own
+`tokio::spawn`ed task, **not** awaited inline in the supervisor's `select!`.
+This is required: a CPU-bound Lua loop that never yields would block the poll of
+an inlined future and starve the signal branch, so the supervisor could never
+react to a stop signal. Running `invoke` as a separate task (on the
+multi-threaded runtime) keeps the supervisor responsive. The supervisor holds an
+`Arc<Runner>` and clones it into the task. Pseudocode:
 
 ```
 backoff = initial
 restarts = 0
 loop {
     start = now
-    let fut = runner.invoke(state)              // pinned, not dropped during grace
+    runner = Arc::new(rebuild_runner())         // fresh VM; reused store Arc
+    handle = tokio::spawn({ let r = runner.clone(); async move {
+        r.invoke(state.clone()).await           // -> LmbResult<Invoked>
+    }})
     outcome = select! {
-        r = &mut fut => Finished(r)             // script returned or errored
+        r = &mut handle => Finished(r)          // script returned or errored
         _ = shutdown_signal() => {              // SIGTERM / SIGINT
-            set_cancel_flag(); record cancel_instant   // feeds the interrupt deadline
+            cancellation.cancel()               // sets flag + cancel instant
             select! {
-                r = &mut fut     => Shutdown    // cooperative finish, or CPU loop
-                                                //   force-interrupted -> fut ends
-                _ = sleep(grace) => Shutdown    // async-parked & ignoring flag:
-                                                //   ABANDON fut (drop cancels the await)
+                r = &mut handle  => Shutdown    // cooperative finish, or CPU loop
+                                                //   force-interrupted -> task ends
+                _ = sleep(grace) => {           // async-parked & ignoring flag:
+                    handle.abort()              //   abort the task (cancels await)
+                    let _ = handle.await        //   reap; interrupt already forced
+                    Shutdown
+                }
             }
         }
     }
@@ -102,14 +109,15 @@ loop {
             log restart with backoff
             sleep(backoff)                            // interruptible by signal
             backoff = min(backoff * 2, max_backoff)
-            runner = rebuild_runner()                 // fresh VM
+            // loop: a fresh Runner / VM is built at the top of the next iteration
         }
     }
 }
 ```
 
-- Every restart **rebuilds the `Runner` / Lua VM** to avoid carrying over
-  corrupted state from a crash.
+- Every restart **rebuilds the `Runner` / Lua VM** (top of the loop) to avoid
+  carrying over corrupted state from a crash. The store `Arc` is reused across
+  rebuilds, so daemon state persists between restarts.
 - A successful (non-error) return is treated as task completion: the daemon
   exits 0 and does not restart.
 - A stable run resets both backoff and the consecutive-failure counter before
@@ -146,16 +154,17 @@ On `SIGTERM` / `SIGINT`:
 1. Set the cancellation flag and record the cancel `Instant` (Lua can observe
    the flag via `ctx.cancelled()`; the interrupt hook uses the instant as its
    force deadline).
-2. Keep awaiting the in-flight `invoke` future, up to `--shutdown-grace`.
+2. Keep awaiting the spawned `invoke` task (`JoinHandle`), up to
+   `--shutdown-grace`.
 3. Force termination uses two complementary mechanisms, because `set_interrupt`
    only fires while Lua bytecode is executing:
    - **CPU-bound Lua loop** (no `await`): the `set_interrupt` hook self-checks
      "cancelled and past cancel-instant + grace" and returns an interrupt error,
-     so the future ends. (The daemon's own grace timer cannot fire here, since a
-     CPU-bound poll blocks until the interrupt unwinds it.)
+     so the task ends. The supervisor stays responsive because `invoke` runs in a
+     separate task (see Architecture), not inline in the `select!`.
    - **Parked at an `await`** (`sleep_ms`, `http.fetch`, ...): `set_interrupt`
-     never fires, so the daemon's grace timer elapses and the future is
-     **abandoned (dropped)** — tokio sleeps and I/O are cancel-on-drop.
+     never fires, so the daemon's grace timer elapses and the supervisor calls
+     `handle.abort()` — tokio sleeps and I/O are cancel-on-drop.
 4. The daemon exits.
 
 This satisfies both cooperative cancellation (the script can finish its current
@@ -165,6 +174,15 @@ is still stopped within the grace period regardless of where it is blocked).
 Only `SIGTERM` and `SIGINT` are handled, both via `tokio::signal::unix`, which
 is Unix-only. On Windows only `Ctrl-C` (`SIGINT`) is available; full Windows
 support is a non-goal.
+
+### Known limitation
+
+Force-interrupting a CPU-bound, never-yielding Lua loop relies on the
+multi-threaded runtime having a free worker to run the supervisor while the loop
+occupies another (the binary's `#[tokio::main]` defaults to one worker per core).
+On a strictly single-core host, such a script that also ignores
+`ctx.cancelled()` cannot be force-stopped on shutdown. Cooperative cancellation
+via `ctx.cancelled()` always works and is the recommended pattern.
 
 ## Runner cancellation capability
 

--- a/docs/superpowers/specs/2026-06-01-daemon-mode-design.md
+++ b/docs/superpowers/specs/2026-06-01-daemon-mode-design.md
@@ -228,8 +228,13 @@ stop signal forces it down after the grace period.
 - Reuse the existing `tracing` setup. Log (structured) on: start, each restart
   with the chosen backoff, backoff reset, giving up after `--max-restarts`, and
   on receiving a stop signal. Restarts/backoff at `warn`; lifecycle at `info`.
-- Reuse the existing `report_error` rendering for script errors before a
-  restart.
+- Script errors are logged concisely via `tracing` (`warn!("script failed: {e}")`),
+  not rendered through `report_error`. A supervised daemon restarts continuously,
+  so a concise one-line log per crash (the `LmbError` `Display` already includes
+  the Lua error location) suits a daemon log stream (e.g. journald) far better
+  than emitting a multi-line source-annotated error box on every restart. The
+  rendered `report_error` view remains the right choice for the one-shot `eval`
+  command, not for the daemon.
 
 ## Testing (TDD)
 

--- a/docs/superpowers/specs/2026-06-01-daemon-mode-design.md
+++ b/docs/superpowers/specs/2026-06-01-daemon-mode-design.md
@@ -50,8 +50,8 @@ lmb daemon --file loop.lua [--state '{...}']
 | `--state` | none | JSON state passed to the script as `ctx.state`. |
 | `--restart-initial-backoff` | `1s` | Wait after the first failure. |
 | `--restart-max-backoff` | `60s` | Upper bound for exponential backoff. |
-| `--restart-reset-after` | `60s` | If the script ran longer than this before failing, reset backoff to the initial value. |
-| `--max-restarts` | `0` (unlimited) | Give up after this many consecutive failures; daemon exits non-zero. |
+| `--restart-reset-after` | `60s` | If the script ran longer than this before failing, treat it as having run stably: reset **both** the backoff and the consecutive-failure counter. |
+| `--max-restarts` | `0` (unlimited) | Give up after this many consecutive failures; daemon exits non-zero. A stable run (see `--restart-reset-after`) resets this counter, so it only catches rapid crash-loops, not sporadic crashes spread over a long uptime. |
 | `--shutdown-grace` | `10s` | After a stop signal, time allowed for the script to finish on its own before force interruption. |
 
 Durations use `jiff::Span` parsing, consistent with the existing `--timeout`
@@ -66,28 +66,43 @@ still set it explicitly to bound a single supervised run.
 
 ## Architecture
 
-The supervisor is a thin Rust loop. Pseudocode:
+The supervisor is a thin Rust loop. The in-flight `invoke` future must **not**
+be dropped on a stop signal — it has to stay alive so the grace period can wait
+on the very same execution. So the future is pinned and the signal branch sets
+the cancellation flag, then keeps awaiting that same future with a grace
+timeout. Pseudocode:
 
 ```
 backoff = initial
 restarts = 0
 loop {
     start = now
-    result = select! {
-        r = runner.invoke(state) => r        // run the script
-        _ = shutdown_signal()    => Shutdown  // SIGTERM / SIGINT
+    let fut = runner.invoke(state)              // pinned, not dropped on signal
+    outcome = select! {
+        r = &mut fut => Finished(r)             // script returned or errored
+        _ = shutdown_signal() => {              // SIGTERM / SIGINT
+            set_cancel_flag()                   // ctx.cancelled() now true
+            select! {
+                r = &mut fut       => Finished(r)   // finished within grace
+                _ = sleep(grace)   => {             // force: set_interrupt fires
+                    (&mut fut).await                // await the now-interrupted run
+                    Shutdown
+                }
+            }
+        }
     }
-    match result {
-        Shutdown            => graceful_shutdown(); break
-        Ok(normal return)   => exit(0)         // task complete, no restart
-        Err(script error)   => {
-            if now - start >= reset_after { backoff = initial }
+    match outcome {
+        Shutdown                       => break       // graceful stop
+        Finished(invoke success)       => exit(0)     // task complete, no restart
+        Finished(invoke failure)       => {
+            stable = (now - start) >= reset_after
+            if stable { backoff = initial; restarts = 0 }
             restarts += 1
             if max_restarts != 0 && restarts >= max_restarts { exit(non-zero) }
             log restart with backoff
-            sleep(backoff)
+            sleep(backoff)                            // interruptible by signal
             backoff = min(backoff * 2, max_backoff)
-            runner = rebuild_runner()           // fresh VM
+            runner = rebuild_runner()                 // fresh VM
         }
     }
 }
@@ -97,6 +112,28 @@ loop {
   corrupted state from a crash.
 - A successful (non-error) return is treated as task completion: the daemon
   exits 0 and does not restart.
+- A stable run resets both backoff and the consecutive-failure counter before
+  counting the current failure.
+- The backoff `sleep` is itself interruptible by a stop signal, so shutdown is
+  responsive even while waiting to restart.
+
+### Success vs failure mapping
+
+`Runner::invoke` returns `LmbResult<Invoked>`, and `Invoked.result` is itself a
+`Result<Value, LmbError>`. The supervisor maps:
+
+- inner `result: Ok(value)` -> **success** -> daemon exits 0.
+- inner `result: Err(e)` (including `LmbError::Timeout` when the user set a
+  timeout) -> **failure** -> restart.
+- outer `Err` from `invoke` (e.g. I/O while building state) -> **failure** ->
+  restart.
+
+### Source buffering
+
+Because each restart rebuilds the VM, the script source is read into a `String`
+**once** at startup and reused for every rebuild — mirroring how `serve`
+buffers its source. This is required for `--file -` (stdin), which cannot be
+re-read.
 
 ## Graceful shutdown
 
@@ -117,11 +154,31 @@ This satisfies both cooperative cancellation (the script can finish its current
 iteration and clean up) and hard cancellation (a script that ignores the flag
 is still stopped).
 
+Only `SIGTERM` and `SIGINT` are handled, both via `tokio::signal::unix`, which
+is Unix-only. On Windows only `Ctrl-C` (`SIGINT`) is available; full Windows
+support is a non-goal.
+
+## Runner cancellation capability
+
+Cancellation is a **generic `Runner` capability**, not a daemon-specific hack.
+`lib.rs` (the library) must not learn about "daemon". Instead the `Runner`
+builder gains an optional cancellation handle (e.g. a
+`tokio_util::sync::CancellationToken` plus an optional force deadline). The
+daemon command in `main.rs` owns the handle and wires it in.
+
+Two consequences for `invoke()`:
+
+- `ctx.cancelled()` is injected into `ctx` **only when a cancellation handle is
+  provided**, so it appears in daemon mode but not in `eval` / `serve`.
+- The VM `set_interrupt` hook can only hold **one** closure. The existing
+  timeout check and the new force-cancel check must live in the **same**
+  closure: it returns an interrupt error if the timeout elapsed *or* if
+  cancellation is active and the grace deadline has passed.
+
 ## Lua-facing API
 
-In daemon mode only, `ctx` gains a `ctx.cancelled()` function that returns the
-current cancellation flag as a boolean. It is injected only for this subcommand,
-so it does not appear in `eval` or `serve`.
+In daemon mode, `ctx` gains a `ctx.cancelled()` function that returns the
+current cancellation flag as a boolean (see "Runner cancellation capability").
 
 ```lua
 -- loop.lua
@@ -153,8 +210,12 @@ Unit tests:
 
 - Backoff computation: exponential growth, capped at `--restart-max-backoff`,
   reset after `--restart-reset-after`.
-- `--max-restarts` giving up with a non-zero exit.
+- `--restart-reset-after` resets both backoff and the consecutive-failure
+  counter (a slow flapping script does not hit `--max-restarts`).
+- `--max-restarts` giving up with a non-zero exit (rapid crash-loop).
 - Timeout defaulting to disabled in daemon mode.
+- Success vs failure mapping: inner `Ok` -> exit 0; inner/outer `Err` ->
+  restart.
 
 Integration tests:
 
@@ -166,5 +227,12 @@ Integration tests:
 
 ## Open questions
 
-None outstanding. Subcommand name (`daemon`), Lua API shape (`ctx.cancelled()`),
-and the daemon-mode timeout default (disabled) are all confirmed.
+None outstanding. Confirmed decisions:
+
+- Subcommand name: `daemon`.
+- Lua API shape: `ctx.cancelled()`.
+- Daemon-mode timeout default: disabled.
+- `--restart-reset-after` resets both backoff and the consecutive-failure
+  counter.
+- Restart only on failure; clean return exits 0.
+- Graceful shutdown: cooperative flag plus grace-period force interrupt.

--- a/docs/superpowers/specs/2026-06-01-daemon-mode-design.md
+++ b/docs/superpowers/specs/2026-06-01-daemon-mode-design.md
@@ -66,11 +66,12 @@ still set it explicitly to bound a single supervised run.
 
 ## Architecture
 
-The supervisor is a thin Rust loop. The in-flight `invoke` future must **not**
-be dropped on a stop signal — it has to stay alive so the grace period can wait
-on the very same execution. So the future is pinned and the signal branch sets
-the cancellation flag, then keeps awaiting that same future with a grace
-timeout. Pseudocode:
+The supervisor is a thin Rust loop. On a stop signal the in-flight `invoke`
+future is **kept alive throughout the grace period** — not dropped immediately —
+so the same execution can finish cooperatively. Only once the grace period
+elapses is it abandoned (see "Graceful shutdown"). So the future is pinned and
+the signal branch sets the cancellation flag, then keeps awaiting that same
+future with a grace timeout. Pseudocode:
 
 ```
 backoff = initial

--- a/docs/superpowers/specs/2026-06-01-daemon-mode-design.md
+++ b/docs/superpowers/specs/2026-06-01-daemon-mode-design.md
@@ -77,17 +77,16 @@ backoff = initial
 restarts = 0
 loop {
     start = now
-    let fut = runner.invoke(state)              // pinned, not dropped on signal
+    let fut = runner.invoke(state)              // pinned, not dropped during grace
     outcome = select! {
         r = &mut fut => Finished(r)             // script returned or errored
         _ = shutdown_signal() => {              // SIGTERM / SIGINT
-            set_cancel_flag()                   // ctx.cancelled() now true
+            set_cancel_flag(); record cancel_instant   // feeds the interrupt deadline
             select! {
-                r = &mut fut       => Finished(r)   // finished within grace
-                _ = sleep(grace)   => {             // force: set_interrupt fires
-                    (&mut fut).await                // await the now-interrupted run
-                    Shutdown
-                }
+                r = &mut fut     => Shutdown    // cooperative finish, or CPU loop
+                                                //   force-interrupted -> fut ends
+                _ = sleep(grace) => Shutdown    // async-parked & ignoring flag:
+                                                //   ABANDON fut (drop cancels the await)
             }
         }
     }
@@ -137,22 +136,30 @@ re-read.
 
 ## Graceful shutdown
 
-The daemon owns a shared cancellation flag (`tokio_util::sync::CancellationToken`
-or `Arc<AtomicBool>`) that is visible to the Lua side.
+The daemon owns a shared cancellation flag (`Arc<AtomicBool>`) plus the
+`Instant` at which cancellation began, both visible to the Lua side and to the
+`set_interrupt` hook.
 
 On `SIGTERM` / `SIGINT`:
 
-1. Set the cancellation flag (Lua can observe it).
-2. Wait for the in-flight `invoke` future to complete, up to `--shutdown-grace`.
-3. If it has not finished within the grace period, force termination via the
-   existing `set_interrupt` hook (inject an interrupt error at the next VM
-   checkpoint). `sleep_ms` and other `await` points also unblock when the
-   future is cancelled.
+1. Set the cancellation flag and record the cancel `Instant` (Lua can observe
+   the flag via `ctx.cancelled()`; the interrupt hook uses the instant as its
+   force deadline).
+2. Keep awaiting the in-flight `invoke` future, up to `--shutdown-grace`.
+3. Force termination uses two complementary mechanisms, because `set_interrupt`
+   only fires while Lua bytecode is executing:
+   - **CPU-bound Lua loop** (no `await`): the `set_interrupt` hook self-checks
+     "cancelled and past cancel-instant + grace" and returns an interrupt error,
+     so the future ends. (The daemon's own grace timer cannot fire here, since a
+     CPU-bound poll blocks until the interrupt unwinds it.)
+   - **Parked at an `await`** (`sleep_ms`, `http.fetch`, ...): `set_interrupt`
+     never fires, so the daemon's grace timer elapses and the future is
+     **abandoned (dropped)** — tokio sleeps and I/O are cancel-on-drop.
 4. The daemon exits.
 
 This satisfies both cooperative cancellation (the script can finish its current
 iteration and clean up) and hard cancellation (a script that ignores the flag
-is still stopped).
+is still stopped within the grace period regardless of where it is blocked).
 
 Only `SIGTERM` and `SIGINT` are handled, both via `tokio::signal::unix`, which
 is Unix-only. On Windows only `Ctrl-C` (`SIGINT`) is available; full Windows
@@ -162,9 +169,9 @@ support is a non-goal.
 
 Cancellation is a **generic `Runner` capability**, not a daemon-specific hack.
 `lib.rs` (the library) must not learn about "daemon". Instead the `Runner`
-builder gains an optional cancellation handle (e.g. a
-`tokio_util::sync::CancellationToken` plus an optional force deadline). The
-daemon command in `main.rs` owns the handle and wires it in.
+builder gains an optional cancellation handle: an `Arc<AtomicBool>` flag plus a
+shared cancel `Instant` and grace duration that together form the interrupt's
+force deadline. The daemon command in `main.rs` owns the handle and wires it in.
 
 Two consequences for `invoke()`:
 
@@ -223,7 +230,11 @@ Integration tests:
 - Script that returns normally -> daemon exits 0, no restart.
 - Cancellation delivered -> `ctx.cancelled()` becomes true and the script
   finishes within the grace period.
-- Script that ignores the flag -> force-interrupted after the grace period.
+- Script that ignores the flag, CPU-bound loop -> interrupt-forced, daemon
+  exits within ~grace.
+- Script that ignores the flag, parked in a long `sleep_ms` -> future abandoned,
+  daemon exits within ~grace (asserts a bounded shutdown time, not an
+  open-ended wait).
 
 ## Open questions
 

--- a/docs/superpowers/specs/2026-06-01-daemon-mode-design.md
+++ b/docs/superpowers/specs/2026-06-01-daemon-mode-design.md
@@ -1,0 +1,170 @@
+# lmb daemon mode — Design
+
+Date: 2026-06-01
+
+## Summary
+
+Add a `lmb daemon` subcommand that runs a long-lived Luau script under
+supervision. Unlike `lmb serve`, it does not handle HTTP requests. The script
+itself is a long-running loop; the daemon supervises it and restarts it on
+failure with exponential backoff, and shuts it down gracefully on signal.
+
+This is the "supervised loop" model: the loop logic lives in Lua, the Rust
+layer is a thin supervisor.
+
+## Goals
+
+- Run a single Luau script that is expected to run indefinitely.
+- Restart the script only when it fails (error / crash), with exponential
+  backoff and an optional restart cap.
+- Exit cleanly (success) when the script returns normally.
+- Shut down gracefully on `SIGTERM` / `SIGINT`: let the script cooperatively
+  finish, then force-interrupt after a grace period.
+- Run as a foreground process; backgrounding is delegated to
+  systemd / docker / shell `&`.
+
+## Non-goals
+
+- No HTTP handling (that is `serve`).
+- No Unix daemonization (no double-fork, no `setsid`, no PID file).
+- No scheduler / cron model (the loop and its sleeps live in Lua).
+- No multi-script supervision (single `--file`).
+
+## CLI surface
+
+New subcommand `daemon`, reusing the existing global `--allow-*`,
+`--store-*`, `--no-store`, and `--timeout` options.
+
+```
+lmb daemon --file loop.lua [--state '{...}']
+           [--restart-initial-backoff 1s]
+           [--restart-max-backoff 60s]
+           [--restart-reset-after 60s]
+           [--max-restarts 0]
+           [--shutdown-grace 10s]
+```
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--file` | (required) | Path to the Lua script, `-` for stdin. |
+| `--state` | none | JSON state passed to the script as `ctx.state`. |
+| `--restart-initial-backoff` | `1s` | Wait after the first failure. |
+| `--restart-max-backoff` | `60s` | Upper bound for exponential backoff. |
+| `--restart-reset-after` | `60s` | If the script ran longer than this before failing, reset backoff to the initial value. |
+| `--max-restarts` | `0` (unlimited) | Give up after this many consecutive failures; daemon exits non-zero. |
+| `--shutdown-grace` | `10s` | After a stop signal, time allowed for the script to finish on its own before force interruption. |
+
+Durations use `jiff::Span` parsing, consistent with the existing `--timeout`
+and `--http-timeout` flags.
+
+### Timeout semantics change
+
+The global `--timeout` defaults to a 30s per-invocation execution timeout. In
+daemon mode that would kill an infinite loop after 30s, so **daemon mode
+defaults `--timeout` to disabled (equivalent to `--timeout 0`)**. The user may
+still set it explicitly to bound a single supervised run.
+
+## Architecture
+
+The supervisor is a thin Rust loop. Pseudocode:
+
+```
+backoff = initial
+restarts = 0
+loop {
+    start = now
+    result = select! {
+        r = runner.invoke(state) => r        // run the script
+        _ = shutdown_signal()    => Shutdown  // SIGTERM / SIGINT
+    }
+    match result {
+        Shutdown            => graceful_shutdown(); break
+        Ok(normal return)   => exit(0)         // task complete, no restart
+        Err(script error)   => {
+            if now - start >= reset_after { backoff = initial }
+            restarts += 1
+            if max_restarts != 0 && restarts >= max_restarts { exit(non-zero) }
+            log restart with backoff
+            sleep(backoff)
+            backoff = min(backoff * 2, max_backoff)
+            runner = rebuild_runner()           // fresh VM
+        }
+    }
+}
+```
+
+- Every restart **rebuilds the `Runner` / Lua VM** to avoid carrying over
+  corrupted state from a crash.
+- A successful (non-error) return is treated as task completion: the daemon
+  exits 0 and does not restart.
+
+## Graceful shutdown
+
+The daemon owns a shared cancellation flag (`tokio_util::sync::CancellationToken`
+or `Arc<AtomicBool>`) that is visible to the Lua side.
+
+On `SIGTERM` / `SIGINT`:
+
+1. Set the cancellation flag (Lua can observe it).
+2. Wait for the in-flight `invoke` future to complete, up to `--shutdown-grace`.
+3. If it has not finished within the grace period, force termination via the
+   existing `set_interrupt` hook (inject an interrupt error at the next VM
+   checkpoint). `sleep_ms` and other `await` points also unblock when the
+   future is cancelled.
+4. The daemon exits.
+
+This satisfies both cooperative cancellation (the script can finish its current
+iteration and clean up) and hard cancellation (a script that ignores the flag
+is still stopped).
+
+## Lua-facing API
+
+In daemon mode only, `ctx` gains a `ctx.cancelled()` function that returns the
+current cancellation flag as a boolean. It is injected only for this subcommand,
+so it does not appear in `eval` or `serve`.
+
+```lua
+-- loop.lua
+return function(ctx)
+    while not ctx.cancelled() do      -- cooperative check
+        local rows = poll_new_rows()
+        for _, r in ipairs(rows) do handle(r) end
+        sleep_ms(60000)               -- unblocks during the grace period
+    end
+    cleanup()                         -- normal return -> daemon exits cleanly
+    return
+end
+```
+
+If the script never checks `ctx.cancelled()` and never returns, it runs until a
+stop signal forces it down after the grace period.
+
+## Error handling & observability
+
+- Reuse the existing `tracing` setup. Log (structured) on: start, each restart
+  with the chosen backoff, backoff reset, giving up after `--max-restarts`, and
+  on receiving a stop signal. Restarts/backoff at `warn`; lifecycle at `info`.
+- Reuse the existing `report_error` rendering for script errors before a
+  restart.
+
+## Testing (TDD)
+
+Unit tests:
+
+- Backoff computation: exponential growth, capped at `--restart-max-backoff`,
+  reset after `--restart-reset-after`.
+- `--max-restarts` giving up with a non-zero exit.
+- Timeout defaulting to disabled in daemon mode.
+
+Integration tests:
+
+- Script that errors immediately -> observe restart count and backoff.
+- Script that returns normally -> daemon exits 0, no restart.
+- Cancellation delivered -> `ctx.cancelled()` becomes true and the script
+  finishes within the grace period.
+- Script that ignores the flag -> force-interrupted after the grace period.
+
+## Open questions
+
+None outstanding. Subcommand name (`daemon`), Lua API shape (`ctx.cancelled()`),
+and the daemon-mode timeout default (disabled) are all confirmed.

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,0 +1,109 @@
+//! Supervised long-running daemon mode.
+
+use std::time::Duration;
+
+/// What the supervisor should do after a failed run.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum RestartDecision {
+    /// Wait this long, then restart.
+    Backoff(Duration),
+    /// Stop restarting; the daemon should exit non-zero.
+    GiveUp,
+}
+
+/// Tracks exponential restart backoff and the consecutive-failure count.
+pub(crate) struct RestartPolicy {
+    initial: Duration,
+    max_backoff: Duration,
+    reset_after: Duration,
+    max_restarts: u32,
+    current_backoff: Duration,
+    consecutive: u32,
+}
+
+impl RestartPolicy {
+    pub(crate) fn new(
+        initial: Duration,
+        max_backoff: Duration,
+        reset_after: Duration,
+        max_restarts: u32,
+    ) -> Self {
+        Self {
+            initial,
+            max_backoff,
+            reset_after,
+            max_restarts,
+            current_backoff: initial,
+            consecutive: 0,
+        }
+    }
+
+    /// Records a failed run of the given duration and returns what to do next.
+    pub(crate) fn record_failure(&mut self, run_duration: Duration) -> RestartDecision {
+        if run_duration >= self.reset_after {
+            self.current_backoff = self.initial;
+            self.consecutive = 0;
+        }
+        self.consecutive += 1;
+        if self.max_restarts != 0 && self.consecutive >= self.max_restarts {
+            return RestartDecision::GiveUp;
+        }
+        let wait = self.current_backoff;
+        self.current_backoff = (self.current_backoff * 2).min(self.max_backoff);
+        RestartDecision::Backoff(wait)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn secs(n: u64) -> Duration {
+        Duration::from_secs(n)
+    }
+
+    #[test]
+    fn backoff_grows_exponentially_and_caps() {
+        // reset_after huge so no run counts as stable; max_restarts unlimited.
+        let mut p = RestartPolicy::new(secs(1), secs(8), secs(3600), 0);
+        // Short failures (0s) never reset.
+        assert_eq!(p.record_failure(secs(0)), RestartDecision::Backoff(secs(1)));
+        assert_eq!(p.record_failure(secs(0)), RestartDecision::Backoff(secs(2)));
+        assert_eq!(p.record_failure(secs(0)), RestartDecision::Backoff(secs(4)));
+        assert_eq!(p.record_failure(secs(0)), RestartDecision::Backoff(secs(8)));
+        // Capped at max_backoff.
+        assert_eq!(p.record_failure(secs(0)), RestartDecision::Backoff(secs(8)));
+    }
+
+    #[test]
+    fn stable_run_resets_backoff_and_counter() {
+        let mut p = RestartPolicy::new(secs(1), secs(60), secs(10), 0);
+        assert_eq!(p.record_failure(secs(0)), RestartDecision::Backoff(secs(1)));
+        assert_eq!(p.record_failure(secs(0)), RestartDecision::Backoff(secs(2)));
+        // A run that lasted >= reset_after resets backoff to initial.
+        assert_eq!(
+            p.record_failure(secs(20)),
+            RestartDecision::Backoff(secs(1))
+        );
+    }
+
+    #[test]
+    fn gives_up_after_max_consecutive_failures() {
+        let mut p = RestartPolicy::new(secs(0), secs(0), secs(3600), 3);
+        assert_eq!(p.record_failure(secs(0)), RestartDecision::Backoff(secs(0)));
+        assert_eq!(p.record_failure(secs(0)), RestartDecision::Backoff(secs(0)));
+        assert_eq!(p.record_failure(secs(0)), RestartDecision::GiveUp);
+    }
+
+    #[test]
+    fn stable_run_prevents_giving_up() {
+        let mut p = RestartPolicy::new(secs(0), secs(0), secs(10), 2);
+        assert_eq!(p.record_failure(secs(0)), RestartDecision::Backoff(secs(0)));
+        // Stable run resets the counter, so the next failure is counted as the first.
+        assert_eq!(
+            p.record_failure(secs(20)),
+            RestartDecision::Backoff(secs(0))
+        );
+        assert_eq!(p.record_failure(secs(0)), RestartDecision::GiveUp);
+    }
+}

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,6 +1,12 @@
 //! Supervised long-running daemon mode.
 
-use std::time::Duration;
+use std::{future::Future, time::Duration, time::Instant};
+
+use bon::Builder;
+use lmb::{Cancellation, LmbStore, Runner, State, permission::Permissions};
+use serde_json::Value;
+use tokio::io::empty;
+use tracing::{info, warn};
 
 /// What the supervisor should do after a failed run.
 #[derive(Debug, PartialEq, Eq)]
@@ -54,12 +60,234 @@ impl RestartPolicy {
     }
 }
 
+/// Configuration for a daemon run.
+#[derive(Builder)]
+pub(crate) struct DaemonConfig {
+    #[builder(into)]
+    pub source: String,
+    #[builder(into)]
+    pub name: Option<String>,
+    pub state: Option<Value>,
+    pub permissions: Option<Permissions>,
+    pub store: Option<LmbStore>,
+    pub http_timeout: Option<Duration>,
+    pub timeout: Option<Duration>,
+    pub initial_backoff: Duration,
+    pub max_backoff: Duration,
+    pub reset_after: Duration,
+    pub max_restarts: u32,
+    pub grace: Duration,
+}
+
+/// Builds a fresh `Runner` for one supervised run.
+fn build_runner(config: &DaemonConfig, cancellation: Cancellation) -> anyhow::Result<Runner> {
+    let runner = Runner::builder(config.source.clone(), empty())
+        .cancellation(cancellation)
+        .maybe_default_name(config.name.clone())
+        .maybe_http_timeout(config.http_timeout)
+        .maybe_permissions(config.permissions.clone())
+        .maybe_store(config.store.clone())
+        .maybe_timeout(config.timeout)
+        .build()?;
+    Ok(runner)
+}
+
+/// Resolves whether a finished run was a clean completion or a failure.
+///
+/// Only called from the task-completion (non-shutdown) path: a forced cancellation
+/// during shutdown lands in the inner select and its result is discarded there.
+fn was_failure(joined: Result<lmb::LmbResult<lmb::Invoked>, tokio::task::JoinError>) -> bool {
+    match joined {
+        Ok(Ok(invoked)) => match invoked.result {
+            Ok(_) => false,
+            Err(e) => {
+                warn!("script failed: {e}");
+                true
+            }
+        },
+        Ok(Err(e)) => {
+            warn!("invoke error: {e}");
+            true
+        }
+        Err(e) => {
+            warn!("daemon task panicked: {e}");
+            true
+        }
+    }
+}
+
+/// Future that resolves when a stop signal (SIGTERM/SIGINT) is received.
+#[cfg(unix)]
+pub(crate) async fn shutdown_signal() {
+    use tokio::signal::unix::{SignalKind, signal};
+    let mut term = signal(SignalKind::terminate()).expect("install SIGTERM handler");
+    let mut int = signal(SignalKind::interrupt()).expect("install SIGINT handler");
+    tokio::select! {
+        _ = term.recv() => {},
+        _ = int.recv() => {},
+    }
+}
+
+/// Future that resolves when Ctrl-C is received (non-Unix fallback).
+#[cfg(not(unix))]
+pub(crate) async fn shutdown_signal() {
+    let _ = tokio::signal::ctrl_c().await;
+}
+
+/// Runs the supervised loop until the script completes, the restart policy gives
+/// up, or a shutdown is requested. Returns the process exit code (0 = success).
+pub(crate) async fn run<F>(config: DaemonConfig, shutdown: F) -> anyhow::Result<u8>
+where
+    F: Future<Output = ()>,
+{
+    let cancellation = Cancellation::new(config.grace);
+    let mut policy = RestartPolicy::new(
+        config.initial_backoff,
+        config.max_backoff,
+        config.reset_after,
+        config.max_restarts,
+    );
+    tokio::pin!(shutdown);
+
+    loop {
+        let runner = build_runner(&config, cancellation.clone())?;
+        let state = config.state.clone();
+        let start = Instant::now();
+        let mut handle = tokio::spawn(async move {
+            let state = State::builder().maybe_state(state).build();
+            runner.invoke().state(state).call().await
+        });
+
+        let shutting_down = tokio::select! {
+            // `biased` + shutdown-first: whenever a stop signal is ready it is always
+            // selected, so the (reused) shutdown future is never polled after it
+            // completes — avoids a Poll::Ready-after-completion contract violation.
+            biased;
+            _ = &mut shutdown => {
+                info!("received stop signal, shutting down");
+                cancellation.cancel();
+                tokio::select! {
+                    biased;
+                    _ = &mut handle => {}
+                    _ = tokio::time::sleep(config.grace) => {
+                        warn!("grace period elapsed, aborting script");
+                        handle.abort();
+                        let _ = handle.await;
+                    }
+                }
+                true
+            }
+            joined = &mut handle => {
+                if !was_failure(joined) {
+                    info!("script returned, daemon exiting");
+                    return Ok(0);
+                }
+                false
+            }
+        };
+
+        if shutting_down {
+            return Ok(0);
+        }
+
+        match policy.record_failure(start.elapsed()) {
+            RestartDecision::GiveUp => {
+                warn!("max restarts reached, giving up");
+                return Ok(1);
+            }
+            RestartDecision::Backoff(wait) => {
+                info!("restarting in {wait:?}");
+                tokio::select! {
+                    biased;
+                    _ = &mut shutdown => {
+                        info!("stop signal during backoff, exiting");
+                        return Ok(0);
+                    }
+                    _ = tokio::time::sleep(wait) => {}
+                }
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    use std::future::pending;
+
     fn secs(n: u64) -> Duration {
         Duration::from_secs(n)
+    }
+
+    fn config(source: &str, max_restarts: u32, grace: Duration) -> DaemonConfig {
+        DaemonConfig::builder()
+            .source(source.to_string())
+            .initial_backoff(Duration::ZERO)
+            .max_backoff(Duration::ZERO)
+            .reset_after(secs(3600))
+            .max_restarts(max_restarts)
+            .grace(grace)
+            .build()
+    }
+
+    #[tokio::test]
+    async fn exits_success_when_script_returns() {
+        let cfg = config("return function(ctx) return 1 end", 0, secs(1));
+        let code = run(cfg, pending::<()>()).await.unwrap();
+        assert_eq!(code, 0);
+    }
+
+    #[tokio::test]
+    async fn exits_failure_after_max_restarts() {
+        let cfg = config("return function(ctx) error('boom') end", 2, secs(1));
+        let code = run(cfg, pending::<()>()).await.unwrap();
+        assert_eq!(code, 1);
+    }
+
+    #[tokio::test]
+    async fn graceful_shutdown_cooperative_returns_success() {
+        let cfg = config(
+            "return function(ctx) while not ctx.cancelled() do sleep_ms(5) end return end",
+            0,
+            secs(1),
+        );
+        let shutdown = async { tokio::time::sleep(Duration::from_millis(40)).await };
+        let code = tokio::time::timeout(secs(5), run(cfg, shutdown))
+            .await
+            .expect("should not hang")
+            .unwrap();
+        assert_eq!(code, 0);
+    }
+
+    #[tokio::test]
+    async fn graceful_shutdown_abandons_async_parked_script() {
+        let cfg = config(
+            "return function(ctx) sleep_ms(600000) end",
+            0,
+            Duration::from_millis(150),
+        );
+        let shutdown = async { tokio::time::sleep(Duration::from_millis(40)).await };
+        let code = tokio::time::timeout(secs(5), run(cfg, shutdown))
+            .await
+            .expect("should not hang")
+            .unwrap();
+        assert_eq!(code, 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn graceful_shutdown_force_interrupts_cpu_loop() {
+        let cfg = config(
+            "return function(ctx) while true do end end",
+            0,
+            Duration::from_millis(150),
+        );
+        let shutdown = async { tokio::time::sleep(Duration::from_millis(40)).await };
+        let code = tokio::time::timeout(secs(5), run(cfg, shutdown))
+            .await
+            .expect("should not hang")
+            .unwrap();
+        assert_eq!(code, 0);
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -140,6 +140,7 @@ pub(crate) async fn run<F>(config: DaemonConfig, shutdown: F) -> anyhow::Result<
 where
     F: Future<Output = ()>,
 {
+    info!("daemon starting");
     let cancellation = Cancellation::new(config.grace);
     let mut policy = RestartPolicy::new(
         config.initial_backoff,
@@ -190,7 +191,14 @@ where
             return Ok(0);
         }
 
-        match policy.record_failure(start.elapsed()) {
+        // A run that lasted at least `reset_after` is considered stable;
+        // `RestartPolicy::record_failure` resets the backoff and failure counter
+        // in that case. Log it here (the policy itself is pure / log-free).
+        let ran = start.elapsed();
+        if ran >= config.reset_after {
+            info!("script ran stably for {ran:?}, resetting backoff and failure count");
+        }
+        match policy.record_failure(ran) {
             RestartDecision::GiveUp => {
                 warn!("max restarts reached, giving up");
                 return Ok(1);

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -298,6 +298,46 @@ mod tests {
         assert_eq!(code, 0);
     }
 
+    #[tokio::test]
+    async fn was_failure_flags_invoke_error_and_panic() {
+        // Outer invoke error: returning a function cannot be serialized into a
+        // Value, so `invoke` yields `Ok(Err(_))`.
+        let cfg = config("return function(ctx) return function() end end", 0, secs(1));
+        let runner = build_runner(&cfg, Cancellation::new(secs(1))).unwrap();
+        let state = State::builder().build();
+        let invoke_err: Result<lmb::LmbResult<lmb::Invoked>, tokio::task::JoinError> =
+            Ok(runner.invoke().state(state).call().await);
+        assert!(matches!(invoke_err, Ok(Err(_))));
+        assert!(was_failure(invoke_err));
+
+        // A panic in the spawned task surfaces as a `JoinError`.
+        let panicked: Result<lmb::LmbResult<lmb::Invoked>, tokio::task::JoinError> =
+            tokio::spawn(async { panic!("boom") })
+                .await
+                .map(|()| unreachable!());
+        assert!(was_failure(panicked));
+    }
+
+    #[tokio::test]
+    async fn shutdown_during_backoff_exits_success() {
+        // First run fails fast, entering a long backoff; the stop signal lands
+        // during that wait and must exit cleanly (code 0).
+        let cfg = DaemonConfig::builder()
+            .source("return function(ctx) error('boom') end")
+            .initial_backoff(Duration::from_millis(500))
+            .max_backoff(Duration::from_millis(500))
+            .reset_after(secs(3600))
+            .max_restarts(0)
+            .grace(secs(1))
+            .build();
+        let shutdown = async { tokio::time::sleep(Duration::from_millis(60)).await };
+        let code = tokio::time::timeout(secs(5), run(cfg, shutdown))
+            .await
+            .expect("should not hang")
+            .unwrap();
+        assert_eq!(code, 0);
+    }
+
     #[test]
     fn backoff_grows_exponentially_and_caps() {
         // reset_after huge so no run counts as stable; max_restarts unlimited.

--- a/src/fixtures/daemon/always-error.lua
+++ b/src/fixtures/daemon/always-error.lua
@@ -1,0 +1,3 @@
+return function(ctx)
+    error("boom")
+end

--- a/src/fixtures/daemon/log-watch.lua
+++ b/src/fixtures/daemon/log-watch.lua
@@ -1,0 +1,31 @@
+-- Daemon example: follow a log file and print every line containing "ERROR".
+--
+-- Run it with the log path passed as state, e.g.:
+--   lmb --allow-read /var/log daemon \
+--       --file src/fixtures/daemon/log-watch.lua \
+--       --state '{"path": "/var/log/app.log"}'
+--
+-- Pass an optional "limit" to stop after that many lines (used by tests);
+-- omit it to follow the log until the daemon receives SIGTERM/SIGINT.
+return function(ctx)
+    local fs = require("@lmb/fs") -- require INSIDE the returned function
+
+    local opts = ctx.state or {}
+    local path = opts.path or error("log-watch: pass --state '{\"path\": \"...\"}'")
+    local limit = opts.limit -- optional; nil = run until cancelled
+
+    local seen, matches = 0, 0
+    for line in fs:tail(path, { from = "start", poll_interval = 100 }) do
+        seen = seen + 1
+        if string.find(line, "ERROR") then
+            matches = matches + 1
+            print(string.format("[match %d @ line %d] %s", matches, seen, line))
+        end
+        if ctx.cancelled() then -- cooperative graceful shutdown
+            break
+        end
+        if limit and seen >= limit then -- bounded run (tests / one-shot scans)
+            break
+        end
+    end
+end

--- a/src/fixtures/daemon/return-immediately.lua
+++ b/src/fixtures/daemon/return-immediately.lua
@@ -1,0 +1,3 @@
+return function(ctx)
+    return true
+end

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -348,18 +348,18 @@ impl Runner {
             let used_memory = used_memory.clone();
             move |vm| {
                 used_memory.fetch_max(vm.used_memory(), Ordering::Relaxed);
-                if let Some(timeout) = timeout {
-                    if start.elapsed() > timeout {
-                        return Err(LuaError::external(Timeout {
-                            elapsed: start.elapsed(),
-                            timeout,
-                        }));
-                    }
+                if let Some(timeout) = timeout
+                    && start.elapsed() > timeout
+                {
+                    return Err(LuaError::external(Timeout {
+                        elapsed: start.elapsed(),
+                        timeout,
+                    }));
                 }
-                if let Some(cancellation) = &cancellation {
-                    if cancellation.force_deadline_passed() {
-                        return Err(LuaError::external(Cancelled));
-                    }
+                if let Some(cancellation) = &cancellation
+                    && cancellation.force_deadline_passed()
+                {
+                    return Err(LuaError::external(Cancelled));
                 }
                 Ok(LuaVmState::Continue)
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,6 +181,7 @@ pub struct Invoked {
 /// A runner for executing Lua scripts with an input stream
 #[derive(Debug)]
 pub struct Runner {
+    cancellation: Option<Cancellation>,
     func: LuaFunction,
     reader: LmbInput,
     store: Option<LmbStore>,
@@ -218,6 +219,7 @@ impl Runner {
     pub fn new<S, R>(
         #[builder(start_fn)] source: S,
         #[builder(start_fn)] reader: R,
+        cancellation: Option<Cancellation>,
         #[builder(into)] default_name: Option<String>,
         http_timeout: Option<Duration>,
         permissions: Option<Permissions>,
@@ -230,6 +232,7 @@ impl Runner {
     {
         let reader = Arc::new(SharedReader::new(reader));
         Self::from_shared_reader(source, reader)
+            .maybe_cancellation(cancellation)
             .maybe_default_name(default_name)
             .maybe_http_timeout(http_timeout)
             .maybe_permissions(permissions)
@@ -243,6 +246,7 @@ impl Runner {
     pub fn from_shared_reader<S>(
         #[builder(start_fn)] source: S,
         #[builder(start_fn)] reader: LmbInput,
+        cancellation: Option<Cancellation>,
         #[builder(into)] default_name: Option<String>,
         http_timeout: Option<Duration>,
         permissions: Option<Permissions>,
@@ -318,6 +322,7 @@ impl Runner {
             store.migrate()?;
         }
         let mut runner = Self {
+            cancellation,
             func,
             reader,
             store,
@@ -337,29 +342,28 @@ impl Runner {
     pub async fn invoke(&self, state: Option<State>) -> LmbResult<Invoked> {
         let used_memory = Arc::new(AtomicUsize::new(0));
         let start = Instant::now();
-        if let Some(timeout) = self.timeout {
-            self.vm.set_interrupt({
-                let used_memory = used_memory.clone();
-                move |vm| {
-                    used_memory.fetch_max(vm.used_memory(), Ordering::Relaxed);
+        let timeout = self.timeout;
+        let cancellation = self.cancellation.clone();
+        self.vm.set_interrupt({
+            let used_memory = used_memory.clone();
+            move |vm| {
+                used_memory.fetch_max(vm.used_memory(), Ordering::Relaxed);
+                if let Some(timeout) = timeout {
                     if start.elapsed() > timeout {
                         return Err(LuaError::external(Timeout {
                             elapsed: start.elapsed(),
                             timeout,
                         }));
                     }
-                    Ok(LuaVmState::Continue)
                 }
-            });
-        } else {
-            self.vm.set_interrupt({
-                let used_memory = used_memory.clone();
-                move |vm| {
-                    used_memory.fetch_max(vm.used_memory(), Ordering::Relaxed);
-                    Ok(LuaVmState::Continue)
+                if let Some(cancellation) = &cancellation {
+                    if cancellation.force_deadline_passed() {
+                        return Err(LuaError::external(Cancelled));
+                    }
                 }
-            });
-        }
+                Ok(LuaVmState::Continue)
+            }
+        });
 
         let ctx = self.vm.create_table()?;
         if let Some(state) = &state {
@@ -374,6 +378,14 @@ impl Runner {
             ctx.set(
                 "store",
                 StoreBinding::builder().store(lmb_store.clone()).build(),
+            )?;
+        }
+        if let Some(cancellation) = &self.cancellation {
+            let cancellation = cancellation.clone();
+            ctx.set(
+                "cancelled",
+                self.vm
+                    .create_function(move |_, ()| Ok(cancellation.is_cancelled()))?,
             )?;
         }
 
@@ -406,6 +418,8 @@ impl Runner {
                             return Ok(invoked
                                 .result(Err(LmbError::Timeout(timeout.clone())))
                                 .build());
+                        } else if ee.downcast_ref::<Cancelled>().is_some() {
+                            return Ok(invoked.result(Err(LmbError::Cancelled(Cancelled))).build());
                         } else {
                             return Ok(invoked.result(Err(LmbError::Lua(e))).build());
                         }
@@ -631,5 +645,48 @@ mod tests {
         // After the grace window, the force deadline has passed.
         std::thread::sleep(Duration::from_millis(100));
         assert!(c.force_deadline_passed());
+    }
+
+    #[tokio::test]
+    async fn ctx_cancelled_is_observable_and_cooperative() {
+        use std::time::Duration;
+        use tokio::io::empty;
+        let cancellation = Cancellation::new(Duration::from_secs(10));
+        // Script loops until ctx.cancelled() becomes true, then returns "stopped".
+        let source = r#"return function(ctx)
+            while not ctx.cancelled() do sleep_ms(5) end
+            return "stopped"
+        end"#;
+        let runner = Runner::builder(source, empty())
+            .cancellation(cancellation.clone())
+            .build()
+            .unwrap();
+        let handle = tokio::spawn(async move { runner.invoke().call().await });
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        cancellation.cancel();
+        let invoked = handle.await.unwrap().unwrap();
+        assert_eq!(invoked.result.unwrap(), json!("stopped"));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cpu_loop_is_force_interrupted_after_grace() {
+        use std::time::Duration;
+        use tokio::io::empty;
+        let cancellation = Cancellation::new(Duration::from_millis(100));
+        // Tight CPU loop that ignores ctx.cancelled().
+        let source = r#"return function(ctx) while true do end end"#;
+        let runner = Runner::builder(source, empty())
+            .cancellation(cancellation.clone())
+            .build()
+            .unwrap();
+        let handle: tokio::task::JoinHandle<LmbResult<Invoked>> =
+            tokio::spawn(async move { runner.invoke().call().await });
+        cancellation.cancel();
+        let invoked = tokio::time::timeout(Duration::from_secs(5), handle)
+            .await
+            .expect("invoke should be force-interrupted, not hang")
+            .unwrap()
+            .unwrap();
+        assert!(matches!(invoked.result, Err(LmbError::Cancelled(_))));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -632,6 +632,11 @@ mod tests {
     }
 
     #[test]
+    fn cancelled_error_displays_message() {
+        assert_eq!(Cancelled.to_string(), "Lua script execution was cancelled");
+    }
+
+    #[test]
     fn cancellation_flag_and_force_deadline() {
         use std::time::Duration;
         let c = Cancellation::new(Duration::from_millis(50));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,8 @@ use std::{
     error::Error,
     fmt,
     sync::{
-        Arc,
-        atomic::{AtomicUsize, Ordering},
+        Arc, OnceLock,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
     },
     time::{Duration, Instant},
 };
@@ -61,6 +61,49 @@ impl fmt::Display for Timeout {
 }
 
 impl Error for Timeout {}
+
+/// A cooperative cancellation handle shared between a supervisor and the Lua VM.
+///
+/// `is_cancelled` lets a script poll for shutdown and stop on its own. If it does
+/// not, `force_deadline_passed` reports when the grace period after [`cancel`](Self::cancel)
+/// has elapsed, which the VM interrupt hook uses to forcibly stop a runaway script.
+#[derive(Clone, Debug)]
+pub struct Cancellation {
+    cancelled: Arc<AtomicBool>,
+    cancel_at: Arc<OnceLock<Instant>>,
+    grace: Duration,
+}
+
+impl Cancellation {
+    /// Creates a new, un-cancelled handle with the given force grace period.
+    pub fn new(grace: Duration) -> Self {
+        Self {
+            cancelled: Arc::new(AtomicBool::new(false)),
+            cancel_at: Arc::new(OnceLock::new()),
+            grace,
+        }
+    }
+
+    /// Signals cancellation and records the instant. Idempotent; the first call wins.
+    pub fn cancel(&self) {
+        let _ = self.cancel_at.set(Instant::now());
+        self.cancelled.store(true, Ordering::Release);
+    }
+
+    /// Returns whether cancellation has been signalled (cooperative check).
+    pub fn is_cancelled(&self) -> bool {
+        self.cancelled.load(Ordering::Acquire)
+    }
+
+    /// Returns whether the grace period has elapsed since cancellation began.
+    ///
+    /// Returns `false` if [`cancel`](Self::cancel) has not yet been called.
+    pub fn force_deadline_passed(&self) -> bool {
+        self.cancel_at
+            .get()
+            .is_some_and(|t| t.elapsed() >= self.grace)
+    }
+}
 
 /// Represents the state of the Lua script execution
 #[derive(Builder, Debug)]
@@ -557,5 +600,21 @@ mod tests {
         let result = super::process_pcall_error(&[number_value], &lua);
         let err = result.unwrap();
         assert!(matches!(err, LmbError::LuaValue(Value::Number(n)) if n.as_f64() == Some(42.0)));
+    }
+
+    #[test]
+    fn cancellation_flag_and_force_deadline() {
+        use std::time::Duration;
+        let c = Cancellation::new(Duration::from_millis(50));
+        // Not cancelled initially.
+        assert!(!c.is_cancelled());
+        assert!(!c.force_deadline_passed());
+        // After cancel(), the flag is set but the grace window has not elapsed.
+        c.cancel();
+        assert!(c.is_cancelled());
+        assert!(!c.force_deadline_passed());
+        // After the grace window, the force deadline has passed.
+        std::thread::sleep(Duration::from_millis(100));
+        assert!(c.force_deadline_passed());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,6 +105,18 @@ impl Cancellation {
     }
 }
 
+/// Marker error raised by the VM interrupt hook when a script is forcibly cancelled.
+#[derive(Clone, Debug)]
+pub struct Cancelled;
+
+impl fmt::Display for Cancelled {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Lua script execution was cancelled")
+    }
+}
+
+impl Error for Cancelled {}
+
 /// Represents the state of the Lua script execution
 #[derive(Builder, Debug)]
 pub struct State {
@@ -142,6 +154,9 @@ pub enum LmbError {
     /// Error when the Lua script times out
     #[error("Timeout: {0}")]
     Timeout(#[from] Timeout),
+    /// Error when the Lua script is forcibly cancelled during shutdown
+    #[error("Cancelled: {0}")]
+    Cancelled(#[from] Cancelled),
 }
 
 /// Type alias for the shared reader used in the library.

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ use serde_json::{Value, json};
 use tracing::{Instrument, Level, debug, debug_span, info, warn};
 use tracing_subscriber::{EnvFilter, fmt::format::FmtSpan};
 
+mod daemon;
 mod serve;
 mod tour;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -185,11 +185,50 @@ EXAMPLES:
         #[clap(long, env = "STATE")]
         state: Option<String>,
     },
+    /// Run a Lua script as a supervised long-running daemon (no HTTP)
+    #[clap(after_help = "\
+EXAMPLES:
+    lmb daemon --file loop.lua
+    lmb daemon --file loop.lua --shutdown-grace 30s
+    lmb daemon --file loop.lua --restart-max-backoff 2m --max-restarts 10")]
+    Daemon {
+        /// Path to the Lua script file, use '-' for stdin
+        #[clap(long, value_parser, env = "FILE_PATH")]
+        file: Input,
+        /// JSON state passed to the Lua script as ctx.state
+        #[clap(long, env = "STATE")]
+        state: Option<String>,
+        /// Initial backoff after a failure (e.g., 1s)
+        #[clap(long, default_value = "1s", env = "RESTART_INITIAL_BACKOFF")]
+        restart_initial_backoff: jiff::Span,
+        /// Maximum backoff between restarts (e.g., 60s)
+        #[clap(long, default_value = "60s", env = "RESTART_MAX_BACKOFF")]
+        restart_max_backoff: jiff::Span,
+        /// Reset backoff and failure count after the script runs stably this long
+        #[clap(long, default_value = "60s", env = "RESTART_RESET_AFTER")]
+        restart_reset_after: jiff::Span,
+        /// Give up after this many consecutive failures (0 = unlimited)
+        #[clap(long, default_value_t = 0, env = "MAX_RESTARTS")]
+        max_restarts: u32,
+        /// Grace period for the script to stop after a signal (e.g., 10s)
+        #[clap(long, default_value = "10s", env = "SHUTDOWN_GRACE")]
+        shutdown_grace: jiff::Span,
+    },
 }
 
 fn parse_timeout(span: Option<jiff::Span>) -> anyhow::Result<Option<Duration>> {
     match span {
         None => Ok(Some(Duration::from_secs(30))),
+        Some(t) if t.is_zero() => Ok(None),
+        Some(t) => Ok(Some(Duration::try_from(t)?)),
+    }
+}
+
+/// Like `parse_timeout`, but defaults to disabled (None) when unspecified, since
+/// a supervised loop is expected to run indefinitely.
+fn parse_daemon_timeout(span: Option<jiff::Span>) -> anyhow::Result<Option<Duration>> {
+    match span {
+        None => Ok(None),
         Some(t) if t.is_zero() => Ok(None),
         Some(t) => Ok(Some(Duration::try_from(t)?)),
     }
@@ -497,6 +536,74 @@ async fn try_main() -> anyhow::Result<()> {
             info!("Listening on {}", listener.local_addr()?);
             axum::serve(listener, app).await?;
         }
+        Command::Daemon {
+            mut file,
+            state,
+            restart_initial_backoff,
+            restart_max_backoff,
+            restart_reset_after,
+            max_restarts,
+            shutdown_grace,
+        } => {
+            let state = state
+                .as_ref()
+                .map(|s| match serde_json::from_str::<Value>(s) {
+                    Ok(value) => value,
+                    Err(_) => json!(s.clone()), // treat invalid value as string
+                });
+            debug!("State: {state:?}");
+
+            let http_timeout = parse_timeout(opts.http_timeout)?;
+            debug!("Using HTTP timeout: {http_timeout:?}");
+            let timeout = parse_daemon_timeout(opts.timeout)?;
+            debug!("Using timeout: {timeout:?}");
+
+            let mut source = String::new();
+            file.read_to_string(&mut source)?;
+
+            let name = if file.is_local() {
+                file.path().to_string_lossy().to_string()
+            } else if file.is_std() {
+                "(stdin)".to_string()
+            } else {
+                bail!("Expected a local file or a stdin input, but got: {file}");
+            };
+
+            if opts.store_path.is_none() && !opts.no_store {
+                #[cfg(feature = "postgres")]
+                if opts.store_url.is_none() {
+                    warn!("No store path specified, using in-memory store");
+                }
+                #[cfg(not(feature = "postgres"))]
+                warn!("No store path specified, using in-memory store");
+            }
+            let store = open_store_connection(
+                opts.store_path,
+                #[cfg(feature = "postgres")]
+                opts.store_url,
+                opts.no_store,
+            )?;
+
+            let config = daemon::DaemonConfig::builder()
+                .source(source)
+                .name(name)
+                .maybe_state(state)
+                .permissions(permissions)
+                .maybe_store(store)
+                .maybe_http_timeout(http_timeout)
+                .maybe_timeout(timeout)
+                .initial_backoff(Duration::try_from(restart_initial_backoff)?)
+                .max_backoff(Duration::try_from(restart_max_backoff)?)
+                .reset_after(Duration::try_from(restart_reset_after)?)
+                .max_restarts(max_restarts)
+                .grace(Duration::try_from(shutdown_grace)?)
+                .build();
+
+            let code = daemon::run(config, daemon::shutdown_signal()).await?;
+            if code != 0 {
+                std::process::exit(i32::from(code));
+            }
+        }
     }
 
     Ok(())
@@ -537,4 +644,25 @@ async fn main() -> ExitCode {
         return ExitCode::FAILURE;
     }
     ExitCode::SUCCESS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn daemon_timeout_defaults_to_disabled() {
+        // Unspecified -> disabled (unlike eval/serve which default to 30s).
+        assert_eq!(parse_daemon_timeout(None).unwrap(), None);
+        // Explicit zero -> disabled.
+        assert_eq!(
+            parse_daemon_timeout(Some("0s".parse().unwrap())).unwrap(),
+            None
+        );
+        // Explicit non-zero -> that duration.
+        assert_eq!(
+            parse_daemon_timeout(Some("5s".parse().unwrap())).unwrap(),
+            Some(Duration::from_secs(5))
+        );
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -604,7 +604,7 @@ async fn try_main() -> anyhow::Result<()> {
 
             let code = daemon::run(config, daemon::shutdown_signal()).await?;
             if code != 0 {
-                std::process::exit(i32::from(code));
+                bail!("daemon gave up after reaching the maximum number of restarts");
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,9 @@ EXAMPLES:
     Start an HTTP server:
         lmb serve --file handler.lua --bind 0.0.0.0:3000
 
+    Run a supervised daemon:
+        lmb daemon --file loop.lua
+
     Allow environment variable access:
         lmb --allow-env API_KEY eval --file script.lua
 

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -236,6 +236,45 @@ lmb [..]
     }
 }
 
+mod daemon {
+    use super::*;
+
+    #[test]
+    fn exits_success_when_script_returns() {
+        Command::new(cmd::cargo_bin!("lmb"))
+            .env("NO_COLOR", "true")
+            .args([
+                "--no-store",
+                "daemon",
+                "--file",
+                "src/fixtures/daemon/return-immediately.lua",
+            ])
+            .assert()
+            .success()
+            .stdout_eq(str![]);
+    }
+
+    #[test]
+    fn exits_failure_after_max_restarts() {
+        Command::new(cmd::cargo_bin!("lmb"))
+            .env("NO_COLOR", "true")
+            .args([
+                "--no-store",
+                "daemon",
+                "--file",
+                "src/fixtures/daemon/always-error.lua",
+                "--restart-initial-backoff",
+                "0s",
+                "--restart-max-backoff",
+                "0s",
+                "--max-restarts",
+                "1",
+            ])
+            .assert()
+            .failure();
+    }
+}
+
 mod errors {
     use super::*;
 

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -273,6 +273,47 @@ mod daemon {
             .assert()
             .failure();
     }
+
+    #[test]
+    fn log_watch_prints_error_lines() {
+        // Write a small log, then run the log-watch example with a `limit` so it
+        // stops deterministically after reading every line.
+        let dir = tempfile::tempdir().unwrap();
+        let log = dir.path().join("app.log");
+        std::fs::write(
+            &log,
+            "line 1: INFO ok\n\
+             line 2: ERROR boom\n\
+             line 3: INFO ok\n\
+             line 4: ERROR bad\n\
+             line 5: INFO ok\n",
+        )
+        .unwrap();
+        // Resolve symlinks so the path matches the canonicalized --allow-read root.
+        let log = std::fs::canonicalize(&log).unwrap();
+        let allow = log.parent().unwrap();
+        let state = format!(r#"{{"path":{:?},"limit":5}}"#, log.to_str().unwrap());
+
+        Command::new(cmd::cargo_bin!("lmb"))
+            .env("NO_COLOR", "true")
+            .args([
+                "--no-store",
+                "--allow-read",
+                allow.to_str().unwrap(),
+                "daemon",
+                "--file",
+                "src/fixtures/daemon/log-watch.lua",
+                "--state",
+                &state,
+            ])
+            .assert()
+            .success()
+            .stdout_eq(str![[r#"
+[match 1 @ line 2] line 2: ERROR boom
+[match 2 @ line 4] line 4: ERROR bad
+
+"#]]);
+    }
 }
 
 mod errors {


### PR DESCRIPTION
## Summary

Adds `lmb daemon --file script.lua`, a supervised long-running mode for a Luau script that — unlike `serve` — does not handle HTTP. The script is a long-running loop; the daemon supervises it:

- **Restart on failure** with exponential backoff (capped), a stable-run reset of both backoff and the consecutive-failure counter, and an optional `--max-restarts` give-up.
- **Graceful shutdown** on `SIGTERM`/`SIGINT`: a cooperative `ctx.cancelled()` flag lets the script finish its current iteration; if it ignores the flag, it is force-stopped after `--shutdown-grace` (VM interrupt for CPU-bound loops, task-abort for scripts parked in async waits).
- **Foreground process**: backgrounding is delegated to systemd / docker; no Unix daemonization.
- Per-invocation `--timeout` defaults to **disabled** in daemon mode (so an infinite loop is not killed at 30s).

Each restart rebuilds a fresh Lua VM (crash isolation); the store `Arc` is reused so state persists across restarts.

### Implementation
- `Cancellation` handle + `Cancelled` error wired into `Runner::invoke` (interrupt hook + `ctx.cancelled()`), present only in daemon mode.
- `src/daemon.rs`: `RestartPolicy`, `DaemonConfig`, `shutdown_signal()`, and the `run()` supervisor (spawns each `invoke` as a task so a CPU-bound loop cannot starve the signal branch; biased select prioritizes shutdown).
- `tokio` `signal` + `time` features enabled.

## Test Plan
- [x] `cargo nextest run` — 333 passed (unit: backoff math/cap/reset, give-up, timeout-default, `Cancellation`; in-process supervisor: cooperative shutdown, async-parked abandon, CPU-loop force-interrupt; snapbox CLI: clean-return success, max-restarts failure)
- [x] `cargo clippy` — clean (no new warnings)
- [x] `cargo fmt --check` — clean
- [x] Manual: `lmb daemon --file loop.lua` + `SIGTERM` exits 0 within the grace period

🤖 Generated with [Claude Code](https://claude.com/claude-code)